### PR TITLE
Refactor questionnaire and recommendations experience

### DIFF
--- a/src/app/questionnaire/page.tsx
+++ b/src/app/questionnaire/page.tsx
@@ -1,226 +1,84 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { toPersianNumbers } from "@/lib/api";
-import { useRouter } from "next/navigation";
-import TouchRipple from "@/components/TouchRipple";
+import { useRouter, useSearchParams } from "next/navigation";
+
 import KioskFrame from "@/components/KioskFrame";
+import NavigationControls from "@/components/questionnaire/NavigationControls";
+import OptionGrid from "@/components/questionnaire/OptionGrid";
+import ProgressPanel from "@/components/questionnaire/ProgressPanel";
+import { toPersianNumbers } from "@/lib/api";
 import {
-  Choice,
-  INTENSITY_CHOICES,
-  MOMENT_CHOICES,
-  MOOD_CHOICES,
-  NOTE_CHOICES,
-  STYLE_CHOICES,
-  TIME_CHOICES,
-  LABEL_LOOKUP,
-} from "@/lib/kiosk-options";
+  TEXT,
+  QUESTION_CONFIG,
+  SUMMARY_PREVIEW_LIMIT,
+  type QuestionnaireAnswers,
+  initialAnswers,
+  separatorJoin,
+  sanitizeAnswers,
+  areAnswersEqual,
+  firstIncompleteStep,
+} from "@/lib/questionnaire";
 
-type QuestionType = "multiple" | "single";
-
-interface QuestionnaireAnswers {
-  moods: string[];
-  moments: string[];
-  times: string[];
-  intensity: string[];
-  styles: string[];
-  noteLikes: string[];
-  noteDislikes: string[];
-}
-
-interface QuestionDefinition {
-  title: string;
-  description?: string;
-  type: QuestionType;
-  options: Choice[];
-  key: keyof QuestionnaireAnswers;
-  optional?: boolean;
-  maxSelections?: number;
-}
-
-const TEXT = {
-  progressPrefix: "سوال",
-  progressOf: "از",
-  optional: "اختیاری",
-  requiredHint: "برای ادامه لطفاً یک گزینه را انتخاب کنید.",
-  back: "بازگشت",
-  next: "بعدی",
-  finish: "مشاهده پیشنهادات",
-  noOptions: "موردی در دسترس نیست.",
-  summaryHeading: "گزینه‌های انتخابی",
-  separator: "، ",
-  questions: {
-    moods: {
-      title: "حال‌وهواهای مورد علاقه شما چیست؟",
-      description: "حداکثر دو مورد را انتخاب کنید.",
-    },
-    moments: {
-      title: "این عطر را بیشتر برای چه موقعیت‌هایی می‌خواهید؟",
-      description: "حداکثر سه مورد را انتخاب کنید.",
-    },
-    times: {
-      title: "بیشتر برای چه زمانی از روز؟",
-    },
-    intensity: {
-      title: "شدت پخش بو را ترجیح می‌دهید؟",
-      description: "از ملایم تا قوی.",
-    },
-    styles: {
-      title: "سبک عطر مورد علاقه شما چیست؟",
-    },
-    likes: {
-      title: "به کدام دسته از نُت‌ها علاقه دارید؟",
-      description: "اختیاری؛ تا سه مورد.",
-    },
-    dislikes: {
-      title: "از کدام دسته از نُت‌ها خوشتان نمی‌آید؟",
-      description: "اختیاری؛ تا سه مورد.",
-    },
-  },
-  summaryLabels: {
-    moods: "حال‌وهوا",
-    moments: "موقعیت",
-    times: "زمان",
-    intensity: "شدت",
-    styles: "سبک",
-    likes: "نُت‌های محبوب",
-    dislikes: "نُت‌های نامطلوب",
-  },
-};
-
-const QUESTION_CONFIG: QuestionDefinition[] = [
-  {
-    key: "moods",
-    type: "multiple",
-    options: MOOD_CHOICES,
-    title: TEXT.questions.moods.title,
-    description: TEXT.questions.moods.description,
-    maxSelections: 2,
-  },
-  {
-    key: "moments",
-    type: "multiple",
-    options: MOMENT_CHOICES,
-    title: TEXT.questions.moments.title,
-    description: TEXT.questions.moments.description,
-    maxSelections: 3,
-  },
-  {
-    key: "times",
-    type: "single",
-    options: TIME_CHOICES,
-    title: TEXT.questions.times.title,
-  },
-  {
-    key: "intensity",
-    type: "single",
-    options: INTENSITY_CHOICES,
-    title: TEXT.questions.intensity.title,
-    description: TEXT.questions.intensity.description,
-  },
-  {
-    key: "styles",
-    type: "single",
-    options: STYLE_CHOICES,
-    title: TEXT.questions.styles.title,
-  },
-  {
-    key: "noteLikes",
-    type: "multiple",
-    options: NOTE_CHOICES,
-    title: TEXT.questions.likes.title,
-    description: TEXT.questions.likes.description,
-    optional: true,
-    maxSelections: 3,
-  },
-  {
-    key: "noteDislikes",
-    type: "multiple",
-    options: NOTE_CHOICES,
-    title: TEXT.questions.dislikes.title,
-    description: TEXT.questions.dislikes.description,
-    optional: true,
-    maxSelections: 3,
-  },
-];
-
-const BTN_BASE =
-  "group relative overflow-hidden rounded-3xl border-2 px-4 py-5 text-center text-lg font-semibold transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-transparent tap-highlight touch-target";
-
-const initialAnswers = (): QuestionnaireAnswers => ({
-  moods: [],
-  moments: [],
-  times: [],
-  intensity: [],
-  styles: [],
-  noteLikes: [],
-  noteDislikes: [],
-});
-
-const separatorJoin = (values: string[]) =>
-  values
-    .map((value) => LABEL_LOOKUP[value] ?? value)
-    .filter((value) => value.trim().length > 0)
-    .join(TEXT.separator);
-
-interface OptionButtonProps {
-  option: Choice;
-  isSelected: boolean;
-  disabled: boolean;
-  delayClass: string;
-  onClick: () => void;
-}
-
-const OptionButton: React.FC<OptionButtonProps> = ({ option, isSelected, disabled, delayClass, onClick }) => {
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-
-  const handlePointerDown = React.useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
-    const node = buttonRef.current;
-    const ripple = (TouchRipple as unknown as { emit?: (x: number, y: number) => void }).emit;
-    if (!node || !ripple) return;
-    const rect = node.getBoundingClientRect();
-    ripple(event.clientX - rect.left, event.clientY - rect.top);
-  }, []);
-
-  const visualState = isSelected
-    ? "border-[var(--color-accent)] bg-[var(--accent-soft)] text-[var(--color-accent)] shadow-strong"
-    : "border-white/25 bg-white/6 text-[var(--color-foreground)] hover:border-white/40 hover:bg-white/15";
-
-  return (
-    <button
-      ref={buttonRef}
-      onClick={onClick}
-      onPointerDown={handlePointerDown}
-      disabled={disabled}
-      aria-pressed={isSelected}
-      className={[BTN_BASE, delayClass, visualState, disabled ? "opacity-55 cursor-not-allowed" : "active:scale-95"].join(" ")}
-    >
-      <TouchRipple />
-      <span className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br from-white/12 to-transparent opacity-0 transition-opacity duration-200 group-aria-pressed:opacity-100 group-focus-visible:opacity-100" />
-      <span className="relative flex flex-col items-center gap-1">
-        {option.icon && <span className="text-2xl sm:text-[28px]">{option.icon}</span>}
-        <span className="text-sm sm:text-base font-medium leading-6">{option.label}</span>
-      </span>
-    </button>
-  );
-};
-
-export default function Questionnaire() {
+const Questionnaire: React.FC = () => {
   const router = useRouter();
-  const [currentStep, setCurrentStep] = useState(0);
-  const [answers, setAnswers] = useState<QuestionnaireAnswers>(initialAnswers);
+  const searchParams = useSearchParams();
+
+  const answersFromQuery = useMemo(() => {
+    const param = searchParams.get("answers");
+    if (!param) return null;
+    try {
+      const parsed = JSON.parse(param) as Partial<QuestionnaireAnswers>;
+      return sanitizeAnswers(parsed);
+    } catch (error) {
+      console.warn("Invalid answers provided in query", error);
+      return null;
+    }
+  }, [searchParams]);
+
+  const initialState = answersFromQuery ?? initialAnswers();
+  const [answers, setAnswers] = useState<QuestionnaireAnswers>(initialState);
+  const [currentStep, setCurrentStep] = useState(() => firstIncompleteStep(initialState));
+
+  useEffect(() => {
+    if (!answersFromQuery) return;
+    setAnswers((prev) => (areAnswersEqual(prev, answersFromQuery) ? prev : answersFromQuery));
+    setCurrentStep(firstIncompleteStep(answersFromQuery));
+  }, [answersFromQuery]);
 
   const questions = QUESTION_CONFIG;
   const totalSteps = questions.length;
   const currentQuestion = questions[currentStep];
+  const selectedValues = answers[currentQuestion.key];
+
+  const encodedAnswers = useMemo(() => JSON.stringify(answers), [answers]);
+  const hasAnswers = useMemo(
+    () => questions.some((question) => answers[question.key].length > 0),
+    [answers, questions]
+  );
+
+  useEffect(() => {
+    if (!hasAnswers) {
+      if (searchParams.get("answers")) {
+        router.replace("/questionnaire", { scroll: false });
+      }
+      return;
+    }
+
+    const currentParam = searchParams.get("answers");
+    if (currentParam === encodedAnswers) return;
+    const query = new URLSearchParams({ answers: encodedAnswers }).toString();
+    router.replace(`/questionnaire?${query}`, { scroll: false });
+  }, [encodedAnswers, hasAnswers, router, searchParams]);
 
   const goNext = useCallback(() => {
     if (currentStep < totalSteps - 1) {
       setCurrentStep((step) => Math.min(step + 1, totalSteps - 1));
-    } else {
-      const qs = new URLSearchParams({ answers: JSON.stringify(answers) });
-      router.push(`/recommendations?${qs}`);
+      return;
     }
+
+    const query = new URLSearchParams({ answers: JSON.stringify(sanitizeAnswers(answers)) }).toString();
+    router.push(`/recommendations?${query}`);
   }, [answers, currentStep, router, totalSteps]);
 
   const goBack = useCallback(() => {
@@ -235,12 +93,14 @@ export default function Questionnaire() {
         const isSelected = selected.includes(value);
         const atLimit =
           !isSelected &&
+          currentQuestion.type === "multiple" &&
           typeof currentQuestion.maxSelections === "number" &&
           selected.length >= currentQuestion.maxSelections;
 
         if (currentQuestion.type === "single") {
           return { ...prev, [key]: isSelected ? [] : [value] };
         }
+
         if (atLimit) return prev;
         return {
           ...prev,
@@ -251,18 +111,48 @@ export default function Questionnaire() {
     [currentQuestion]
   );
 
+  const resetCurrent = useCallback(() => {
+    setAnswers((prev) => {
+      const key = currentQuestion.key;
+      if (prev[key].length === 0) return prev;
+      return { ...prev, [key]: [] };
+    });
+  }, [currentQuestion]);
+
+  const resetAll = useCallback(() => {
+    setAnswers(initialAnswers());
+    setCurrentStep(0);
+    router.replace("/questionnaire", { scroll: false });
+  }, [router]);
+
   useEffect(() => {
     if (currentQuestion.type !== "single") return;
-    if (answers[currentQuestion.key].length === 0) return;
+    if (selectedValues.length === 0) return;
     const timer = window.setTimeout(() => {
       goNext();
     }, 420);
     return () => window.clearTimeout(timer);
-  }, [answers, currentQuestion, goNext]);
+  }, [selectedValues, currentQuestion, goNext]);
 
   const progressPercent = Math.round(((currentStep + 1) / totalSteps) * 100);
+  const progressPercentLabel = `${toPersianNumbers(String(progressPercent))}%`;
   const progressLabel = `${TEXT.progressPrefix} ${toPersianNumbers(String(currentStep + 1))} ${TEXT.progressOf} ${toPersianNumbers(String(totalSteps))}`;
-  const canProceed = currentQuestion.optional || answers[currentQuestion.key].length > 0;
+
+  const limitMessage = useMemo(() => {
+    if (currentQuestion.type !== "multiple" || typeof currentQuestion.maxSelections !== "number") {
+      return null;
+    }
+    const max = currentQuestion.maxSelections;
+    const remaining = Math.max(0, max - selectedValues.length);
+    const base = `حداکثر ${toPersianNumbers(String(max))} انتخاب`;
+    if (remaining === 0) {
+      return `${base} تکمیل شد.`;
+    }
+    if (remaining === max) {
+      return `${base} — هنوز انتخابی انجام نشده است.`;
+    }
+    return `${base} — می‌توانید ${toPersianNumbers(String(remaining))} گزینه دیگر برگزینید.`;
+  }, [currentQuestion, selectedValues.length]);
 
   const summaryChips = useMemo(() => {
     const chips: string[] = [];
@@ -273,8 +163,11 @@ export default function Questionnaire() {
     if (answers.styles.length) chips.push(`${TEXT.summaryLabels.styles}: ${separatorJoin(answers.styles)}`);
     if (answers.noteLikes.length) chips.push(`${TEXT.summaryLabels.likes}: ${separatorJoin(answers.noteLikes)}`);
     if (answers.noteDislikes.length) chips.push(`${TEXT.summaryLabels.dislikes}: ${separatorJoin(answers.noteDislikes)}`);
-    return chips.slice(0, 4);
+    return chips.slice(0, SUMMARY_PREVIEW_LIMIT);
   }, [answers]);
+
+  const canProceed = currentQuestion.optional || selectedValues.length > 0;
+  const helperText = currentQuestion.optional ? TEXT.optional : TEXT.requiredHint;
 
   return (
     <KioskFrame>
@@ -284,95 +177,44 @@ export default function Questionnaire() {
           <div className="absolute right-10 bottom-16 h-56 w-56 rounded-full bg-white/20 blur-[120px]" />
         </div>
         <div className="relative flex h-full w-full max-w-[1200px] flex-col gap-6 rounded-3xl glass-deep px-6 py-8 shadow-2xl animate-blur-in">
-          <header className="flex flex-col gap-5 animate-slide-in-right">
-            <div className="flex items-center justify-between">
-              <div className="space-y-2 text-right">
-                <p className="m-0 text-xs font-medium text-muted" aria-live="polite">
-                  {progressLabel}
-                </p>
-                <h1 className="text-3xl font-semibold text-[var(--color-foreground)]">
-                  {currentQuestion.title}
-                </h1>
-                {currentQuestion.description && (
-                  <p className="m-0 text-sm text-muted">{currentQuestion.description}</p>
-                )}
-              </div>
-              <div className="w-44 sm:w-56">
-                <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-white/15">
-                  <div
-                    className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-amber-200 via-amber-300 to-orange-300 shadow-lg transition-[width] duration-500"
-                    style={{ width: `${progressPercent}%` }}
-                  />
-                </div>
-                <span className="mt-2 block text-right text-xs font-medium text-[var(--color-accent)]">
-                  {toPersianNumbers(String(progressPercent))}%
-                </span>
-              </div>
-            </div>
-            {summaryChips.length > 0 && (
-              <div className="flex flex-wrap justify-end gap-2 text-xs text-muted">
-                <span className="rounded-full border border-white/25 px-3 py-1 font-semibold text-[var(--color-accent)]">
-                  {TEXT.summaryHeading}
-                </span>
-                {summaryChips.map((chip, index) => (
-                  <span key={index} className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs">
-                    {chip}
-                  </span>
-                ))}
-              </div>
-            )}
-          </header>
+          <ProgressPanel
+            title={currentQuestion.title}
+            description={currentQuestion.description}
+            progressLabel={progressLabel}
+            progressPercent={progressPercent}
+            progressPercentLabel={progressPercentLabel}
+            summaryHeading={TEXT.summaryHeading}
+            summaryChips={summaryChips}
+            optional={Boolean(currentQuestion.optional)}
+            optionalLabel={TEXT.optional}
+            limitMessage={limitMessage}
+            onResetCurrent={resetCurrent}
+            onResetAll={resetAll}
+          />
 
           <section className="flex flex-1 items-center justify-center animate-scale-in animate-delay-2">
-            <div className="grid w-full max-w-[900px] grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 sm:gap-4">
-              {currentQuestion.options.map((option, idx) => {
-                const values = answers[currentQuestion.key];
-                const isSelected = values.includes(option.value);
-                const disabled =
-                  !isSelected &&
-                  typeof currentQuestion.maxSelections === "number" &&
-                  values.length >= currentQuestion.maxSelections;
-                const delayClass = idx % 3 === 1 ? "animate-delay-1" : idx % 3 === 2 ? "animate-delay-2" : "animate-delay-0";
-                return (
-                  <OptionButton
-                    key={option.value}
-                    option={option}
-                    isSelected={isSelected}
-                    disabled={disabled}
-                    delayClass={delayClass}
-                    onClick={() => toggle(option.value)}
-                  />
-                );
-              })}
-              {currentQuestion.options.length === 0 && (
-                <div className="col-span-full flex h-full items-center justify-center rounded-3xl border border-white/15 bg-white/10 text-sm text-muted">
-                  {TEXT.noOptions}
-                </div>
-              )}
-            </div>
+            <OptionGrid
+              question={currentQuestion}
+              selectedValues={selectedValues}
+              onToggle={toggle}
+              emptyMessage={TEXT.noOptions}
+            />
           </section>
 
-          <footer className="flex items-center justify-between gap-3 animate-slide-in-left animate-delay-3">
-            <button
-              onClick={goBack}
-              disabled={currentStep === 0}
-              className="btn-ghost w-32 tap-highlight touch-target touch-feedback"
-            >
-              {TEXT.back}
-            </button>
-            <span className="text-xs text-muted">
-              {currentQuestion.optional ? TEXT.optional : TEXT.requiredHint}
-            </span>
-            <button
-              onClick={goNext}
-              disabled={!canProceed}
-              className="btn w-32 tap-highlight touch-target touch-feedback"
-            >
-              {currentStep === totalSteps - 1 ? TEXT.finish : TEXT.next}
-            </button>
-          </footer>
+          <NavigationControls
+            onBack={goBack}
+            onNext={goNext}
+            disableBack={currentStep === 0}
+            disableNext={!canProceed}
+            backLabel={TEXT.back}
+            nextLabel={currentStep === totalSteps - 1 ? TEXT.finish : TEXT.next}
+            helperText={helperText}
+            isOptional={Boolean(currentQuestion.optional)}
+          />
         </div>
       </div>
     </KioskFrame>
   );
-}
+};
+
+export default Questionnaire;

--- a/src/app/recommendations/page.tsx
+++ b/src/app/recommendations/page.tsx
@@ -1,45 +1,29 @@
 "use client";
 
-import React, { Suspense, useEffect, useState } from "react";
+import React, { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
+
 import AnimatedBackground from "@/components/AnimatedBackground";
-import TouchRipple from "@/components/TouchRipple";
-import { getPerfumes, type Perfume } from "@/lib/api";
-import { LABEL_LOOKUP, NOTE_CHOICES } from "@/lib/kiosk-options";
-
-interface QuestionnaireAnswers {
-  moods: string[];
-  moments: string[];
-  times: string[];
-  intensity: string[];
-  styles: string[];
-  noteLikes: string[];
-  noteDislikes: string[];
-}
-
-type RankedPerfume = Perfume & {
-  score: number;
-  maxScore: number;
-  matchPercentage: number;
-  reasons: string[];
-};
-
-const WEIGHTS = {
-  moods: 28,
-  moments: 18,
-  times: 10,
-  intensity: 12,
-  styles: 8,
-  notes: 18,
-  synergy: 8,
-} as const;
-
-const PENALTY_WEIGHTS = {
-  dislikes: 14,
-  weakCoverage: 10,
-} as const;
+import MatchCard, {
+  type CompactMode,
+  type DisplayReason,
+} from "@/components/recommendations/MatchCard";
+import { getPerfumes, toPersianNumbers } from "@/lib/api";
+import { LABEL_LOOKUP } from "@/lib/kiosk-options";
+import {
+  TEXT as QUESTION_TEXT,
+  SUMMARY_PREVIEW_LIMIT,
+  type QuestionnaireAnswers,
+  sanitizeAnswers,
+  separatorJoin,
+} from "@/lib/questionnaire";
+import {
+  describeMatchQuality,
+  rankPerfumes,
+  type MatchReason,
+  type RankedPerfume,
+} from "@/lib/recommendation-engine";
 
 const TEXT = {
   loading: "در حال بارگذاری",
@@ -47,636 +31,236 @@ const TEXT = {
   startQuestionnaire: "شروع پرسشنامه",
   heading: "پیشنهادهای شما",
   empty: "مورد مناسبی پیدا نشد. لطفاً پاسخ‌ها را تغییر دهید.",
-  reasonMood: "حال‌وهوا",
-  reasonMoment: "موقعیت",
-  reasonTime: "زمان استفاده",
-  reasonIntensity: "شدت پخش بو",
-  reasonStyle: "سبک مورد انتظار",
-  reasonNotes: "یادداشت محبوب",
-  penaltyDislikes: "برخی نُت‌های نامطلوب شناسایی شد",
-  synergy: "ترکیب انتخاب‌ها بسیار هماهنگ است",
-  weakCoverage: "پوشش ترجیحات اصلی کامل نیست",
-};
-
-const STRONG_KEYWORDS = [
-  "intense",
-  "rich",
-  "deep",
-  "oud",
-  "oriental",
-  "amber",
-  "noir",
-  "night",
-  "warm",
-];
-const LIGHT_KEYWORDS = [
-  "light",
-  "soft",
-  "fresh",
-  "clean",
-  "citrus",
-  "airy",
-  "green",
-  "bright",
-];
-
-const NOTE_KEYWORDS: Record<string, string[]> = Object.fromEntries(
-  NOTE_CHOICES.map((choice) => [choice.value, choice.keywords])
-);
-
-const MOOD_PROFILES: Record<
-  string,
-  { families: string[]; characters: string[]; notes: string[] }
-> = {
-  fresh: {
-    families: ["fresh", "citrus", "aquatic", "green", "aromatic"],
-    characters: ["fresh", "cool", "clean", "energetic", "marine", "crisp"],
-    notes: [...(NOTE_KEYWORDS.citrus ?? []), ...(NOTE_KEYWORDS.green ?? [])],
+  summaryHeading: "خلاصه انتخاب‌ها",
+  refine: "ویرایش پاسخ‌ها",
+  restart: "شروع دوباره",
+  coverage: "پوشش ترجیحات",
+  intensity: {
+    light: "ملایم",
+    medium: "متعادل",
+    strong: "قوی",
+  } as const,
+  reasons: {
+    mood: "حال‌وهوا",
+    moment: "موقعیت",
+    time: "زمان استفاده",
+    intensity: "شدت پخش بو",
+    style: "سبک مورد انتظار",
+    note: "یادداشت محبوب",
+    synergy: "ترکیب انتخاب‌ها هماهنگ است",
   },
-  sweet: {
-    families: ["gourmand", "sweet", "oriental"],
-    characters: ["sweet", "gourmand", "creamy", "dessert"],
-    notes: [...(NOTE_KEYWORDS.sweet ?? [])],
-  },
-  warm: {
-    families: ["spicy", "oriental", "amber"],
-    characters: ["warm", "spicy", "amber", "sensual"],
-    notes: [...(NOTE_KEYWORDS.spicy ?? []), ...(NOTE_KEYWORDS.oriental ?? [])],
-  },
-  floral: {
-    families: ["floral", "powdery"],
-    characters: ["floral", "soft", "romantic", "powdery"],
-    notes: [...(NOTE_KEYWORDS.floral ?? []), ...(NOTE_KEYWORDS.musky ?? [])],
-  },
-  woody: {
-    families: ["woody", "chypre", "mossy"],
-    characters: ["wood", "earthy", "classic", "smoky"],
-    notes: [...(NOTE_KEYWORDS.woody ?? []), "patchouli", "leather"],
+  warnings: {
+    dislikePenalty: "برخی نُت‌های نامطلوب مشاهده شد",
+    coveragePenalty: "پوشش ترجیحات اصلی کامل نیست",
   },
 };
 
-const MOMENT_PROFILES: Record<
-  string,
-  {
-    seasons?: string[];
-    intensity?: Array<"light" | "medium" | "strong">;
-    characters?: string[];
-    notes?: string[];
-  }
-> = {
-  daily: {
-    seasons: ["all", "cool", "warm"],
-    intensity: ["light", "medium"],
-    characters: ["fresh", "clean", "soft", "balanced"],
-  },
-  evening: {
-    seasons: ["cool", "cold"],
-    intensity: ["medium", "strong"],
-    characters: ["warm", "sweet", "intense", "sensual"],
-  },
-  outdoor: {
-    seasons: ["warm", "all"],
-    intensity: ["light", "medium"],
-    characters: ["fresh", "green", "citrus", "airy"],
-    notes: [...(NOTE_KEYWORDS.citrus ?? []), ...(NOTE_KEYWORDS.green ?? [])],
-  },
-  gift: {
-    seasons: ["all"],
-    intensity: ["light", "medium"],
-    characters: ["soft", "smooth", "elegant"],
-    notes: [...(NOTE_KEYWORDS.floral ?? []), ...(NOTE_KEYWORDS.sweet ?? [])],
-  },
-};
+type IntensityKey = keyof typeof TEXT.intensity;
 
-const TIME_PROFILES: Record<
-  string,
-  { characters: string[]; intensity?: Array<"light" | "medium" | "strong"> }
-> = {
-  day: {
-    characters: ["fresh", "clean", "bright", "light"],
-    intensity: ["light", "medium"],
-  },
-  night: {
-    characters: ["warm", "intense", "sensual", "deep"],
-    intensity: ["medium", "strong"],
-  },
-  anytime: {
-    characters: ["versatile", "balanced"],
-  },
-};
+type ReasonCode = keyof typeof TEXT.reasons | keyof typeof TEXT.warnings;
 
-const STYLE_MAP: Record<string, string[]> = {
-  feminine: ["female"],
-  masculine: ["male"],
-  unisex: ["unisex"],
-  any: ["female", "male", "unisex"],
-};
+const formatReason = (reason: MatchReason): DisplayReason | null => {
+  const valueLabel = reason.value ? LABEL_LOOKUP[reason.value] ?? reason.value : undefined;
 
-const normalize = (value?: string) => value?.toLowerCase() ?? "";
-
-const includesAny = (target: string, keywords: string[]) =>
-  keywords.some((keyword) => target.includes(keyword));
-
-const notesMatch = (notes: string[], keywords: string[]) =>
-  keywords.some((keyword) => notes.some((note) => note.includes(keyword)));
-
-const deriveIntensity = (perfume: Perfume): "light" | "medium" | "strong" => {
-  const base = `${perfume.character ?? ""} ${
-    perfume.family ?? ""
-  }`.toLowerCase();
-  if (STRONG_KEYWORDS.some((keyword) => base.includes(keyword)))
-    return "strong";
-  if (LIGHT_KEYWORDS.some((keyword) => base.includes(keyword))) return "light";
-  const noteCount = perfume.allNotes.length;
-  if (noteCount >= 9) return "strong";
-  if (noteCount <= 4) return "light";
-  return "medium";
-};
-
-const mapSeason = (season?: string) => {
-  const normalized = normalize(season);
-  if (normalized.includes("warm")) return "warm";
-  if (normalized.includes("cold")) return "cold";
-  if (normalized.includes("cool")) return "cool";
-  return "all";
-};
-
-const moodScore = (perfume: Perfume, value: string, notes: string[]) => {
-  const profile = MOOD_PROFILES[value];
-  if (!profile) return 0;
-  const family = normalize(perfume.family);
-  const character = normalize(perfume.character);
-  let score = 0;
-  if (includesAny(family, profile.families)) score += 0.4;
-  if (includesAny(character, profile.characters)) score += 0.4;
-  if (notesMatch(notes, profile.notes)) score += 0.2;
-  return score;
-};
-
-const momentScore = (
-  perfume: Perfume,
-  value: string,
-  intensity: "light" | "medium" | "strong",
-  notes: string[]
-) => {
-  const profile = MOMENT_PROFILES[value];
-  if (!profile) return 0;
-  const seasonMatch = profile.seasons?.includes(mapSeason(perfume.season))
-    ? 0.4
-    : 0;
-  const intensityMatch = profile.intensity?.includes(intensity) ? 0.3 : 0;
-  const characterMatch =
-    profile.characters &&
-    includesAny(normalize(perfume.character), profile.characters)
-      ? 0.2
-      : 0;
-  const noteMatch = profile.notes && notesMatch(notes, profile.notes) ? 0.1 : 0;
-  return seasonMatch + intensityMatch + characterMatch + noteMatch;
-};
-
-const timeScore = (
-  perfume: Perfume,
-  value: string,
-  intensity: "light" | "medium" | "strong"
-) => {
-  const profile = TIME_PROFILES[value];
-  if (!profile) return 0;
-  const charMatch = includesAny(
-    normalize(perfume.character),
-    profile.characters
-  )
-    ? 0.6
-    : 0;
-  const intensityMatch = profile.intensity?.includes(intensity) ? 0.4 : 0;
-  return charMatch + intensityMatch;
-};
-
-const intensityScore = (perfumeIntensity: string, desired: string[]) => {
-  if (desired.length === 0) return 0;
-  const wanted = desired[0];
-  if (wanted === perfumeIntensity) return 1;
-  if (wanted === "medium" || perfumeIntensity === "medium") return 0.6;
-  return 0.2;
-};
-
-const styleScore = (perfume: Perfume, styles: string[]) => {
-  if (styles.length === 0) return 0;
-  const gender = normalize(perfume.gender);
-  const preferred = STYLE_MAP[styles[0]] ?? STYLE_MAP.any;
-  return preferred.includes(gender) ? 1 : 0.3;
-};
-
-const notePreferenceScore = (
-  notes: string[],
-  desired: string[]
-): { score: number; best: string | null } => {
-  if (desired.length === 0) return { score: 0, best: null };
-  let matches = 0;
-  let bestValue: string | null = null;
-  let bestHits = -1;
-  for (const value of desired) {
-    const keywords = NOTE_KEYWORDS[value] ?? [];
-    const hits = keywords.filter((keyword) =>
-      notes.some((note) => note.includes(keyword))
-    ).length;
-    if (hits > 0) {
-      matches += 1;
-      if (hits > bestHits) {
-        bestHits = hits;
-        bestValue = value;
-      }
+  switch (reason.code as ReasonCode) {
+    case "mood":
+    case "moment":
+    case "time":
+    case "intensity":
+    case "style":
+    case "note": {
+      if (!valueLabel) return null;
+      return {
+        tone: reason.tone,
+        text: `${TEXT.reasons[reason.code]}: ${valueLabel}`,
+      };
     }
+    case "synergy":
+      return { tone: "positive", text: TEXT.reasons.synergy };
+    case "dislikePenalty":
+      return { tone: "warning", text: TEXT.warnings.dislikePenalty };
+    case "coveragePenalty":
+      return { tone: "warning", text: TEXT.warnings.coveragePenalty };
+    default:
+      return null;
   }
-  return { score: matches / desired.length, best: bestValue };
 };
 
-const dislikedMatches = (notes: string[], dislikes: string[]) =>
-  dislikes.reduce((total, value) => {
-    const keywords = NOTE_KEYWORDS[value] ?? [];
-    const hits = keywords.filter((keyword) =>
-      notes.some((note) => note.includes(keyword))
-    ).length;
-    return total + hits;
-  }, 0);
+const buildSummary = (answers: QuestionnaireAnswers | null) => {
+  if (!answers) return [] as string[];
+  const chips: string[] = [];
+  if (answers.moods.length) chips.push(`${QUESTION_TEXT.summaryLabels.moods}: ${separatorJoin(answers.moods)}`);
+  if (answers.moments.length) chips.push(`${QUESTION_TEXT.summaryLabels.moments}: ${separatorJoin(answers.moments)}`);
+  if (answers.times.length) chips.push(`${QUESTION_TEXT.summaryLabels.times}: ${separatorJoin(answers.times)}`);
+  if (answers.intensity.length) chips.push(`${QUESTION_TEXT.summaryLabels.intensity}: ${separatorJoin(answers.intensity)}`);
+  if (answers.styles.length) chips.push(`${QUESTION_TEXT.summaryLabels.styles}: ${separatorJoin(answers.styles)}`);
+  if (answers.noteLikes.length) chips.push(`${QUESTION_TEXT.summaryLabels.likes}: ${separatorJoin(answers.noteLikes)}`);
+  if (answers.noteDislikes.length) chips.push(`${QUESTION_TEXT.summaryLabels.dislikes}: ${separatorJoin(answers.noteDislikes)}`);
+  return chips.slice(0, SUMMARY_PREVIEW_LIMIT);
+};
 
-const computeScore = (
-  perfume: Perfume,
-  answers: QuestionnaireAnswers
-): RankedPerfume | null => {
-  const notes = perfume.allNotes.map((note) => note.toLowerCase());
-  const dislikeHits = dislikedMatches(notes, answers.noteDislikes);
+const RecommendationsContent: React.FC = () => {
+  const searchParams = useSearchParams();
+  const [recommendations, setRecommendations] = useState<RankedPerfume[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [answers, setAnswers] = useState<QuestionnaireAnswers | null>(null);
+  const [compact, setCompact] = useState<CompactMode>("normal");
 
-  const components: Array<{
-    id: keyof typeof WEIGHTS | "notes";
-    weight: number;
-    achieved: number;
-    reason?: string;
-  }> = [];
-  let penaltyScore = 0;
-  const reasons: string[] = [];
-  const perfumeIntensity = deriveIntensity(perfume);
-
-  const addComponent = (
-    id: keyof typeof WEIGHTS | "notes",
-    weight: number,
-    achieved: number,
-    reason?: string
-  ) => {
-    components.push({ id, weight, achieved, reason });
-    if (reason && achieved >= 0.55) {
-      reasons.push(reason);
-    }
-  };
-
-  const addPenalty = (weight: number, severity: number, reason?: string) => {
-    penaltyScore += weight * Math.min(Math.max(severity, 0), 1);
-    if (reason) {
-      reasons.push(reason);
-    }
-  };
-
-  if (answers.moods.length) {
-    let total = 0;
-    let strongestValue: string | null = null;
-    let strongestRatio = 0;
-    answers.moods.forEach((value) => {
-      const ratio = moodScore(perfume, value, notes);
-      total += ratio;
-      if (ratio > strongestRatio) {
-        strongestRatio = ratio;
-        strongestValue = value;
-      }
-    });
-    const achieved = total / answers.moods.length;
-    const reason = strongestValue && strongestRatio >= 0.55
-      ? `${TEXT.reasonMood}: ${LABEL_LOOKUP[strongestValue]}`
-      : undefined;
-    addComponent("moods", WEIGHTS.moods, achieved, reason);
-  }
-
-  if (answers.moments.length) {
-    let total = 0;
-    let strongestValue: string | null = null;
-    let strongestRatio = 0;
-    answers.moments.forEach((value) => {
-      const ratio = momentScore(perfume, value, perfumeIntensity, notes);
-      total += ratio;
-      if (ratio > strongestRatio) {
-        strongestRatio = ratio;
-        strongestValue = value;
-      }
-    });
-    const achieved = total / answers.moments.length;
-    const reason = strongestValue && strongestRatio >= 0.5
-      ? `${TEXT.reasonMoment}: ${LABEL_LOOKUP[strongestValue]}`
-      : undefined;
-    addComponent("moments", WEIGHTS.moments, achieved, reason);
-  }
-
-  if (answers.times.length) {
-    const ratio = timeScore(perfume, answers.times[0], perfumeIntensity);
-    const reason = ratio >= 0.55 ? `${TEXT.reasonTime}: ${LABEL_LOOKUP[answers.times[0]]}` : undefined;
-    addComponent("times", WEIGHTS.times, ratio, reason);
-  }
-
-  if (answers.intensity.length) {
-    const ratio = intensityScore(perfumeIntensity, answers.intensity);
-    const reason = ratio >= 0.6 ? `${TEXT.reasonIntensity}: ${LABEL_LOOKUP[answers.intensity[0]]}` : undefined;
-    addComponent("intensity", WEIGHTS.intensity, ratio, reason);
-  }
-
-  if (answers.styles.length) {
-    const ratio = styleScore(perfume, answers.styles);
-    const reason = ratio >= 0.7 ? `${TEXT.reasonStyle}: ${LABEL_LOOKUP[answers.styles[0]]}` : undefined;
-    addComponent("styles", WEIGHTS.styles, ratio, reason);
-  }
-
-  if (answers.noteLikes.length) {
-    const noteFeedback = notePreferenceScore(notes, answers.noteLikes);
-    const reason = noteFeedback.best
-      ? `${TEXT.reasonNotes}: ${LABEL_LOOKUP[noteFeedback.best]}`
-      : undefined;
-    addComponent("notes", WEIGHTS.notes, noteFeedback.score, reason);
-  }
-
-  if (dislikeHits > 0) {
-    const severity = Math.min(dislikeHits / 3, 1);
-    addPenalty(PENALTY_WEIGHTS.dislikes, severity, TEXT.penaltyDislikes);
-  }
-
-  const maxScore = components.reduce((sum, item) => sum + item.weight, 0);
-  if (maxScore === 0) {
-    return {
-      ...perfume,
-      score: 0,
-      maxScore: 0,
-      matchPercentage: 0,
-      reasons: [],
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const evaluate = () => {
+      const height = window.innerHeight;
+      if (height < 720) setCompact("ultra");
+      else if (height < 880) setCompact("tight");
+      else setCompact("normal");
     };
-  }
+    evaluate();
+    window.addEventListener("resize", evaluate);
+    return () => window.removeEventListener("resize", evaluate);
+  }, []);
 
-  const coreComponents = components.filter((item) =>
-    ["moods", "moments", "times", "intensity", "styles"].includes(item.id)
-  );
+  useEffect(() => {
+    async function generate() {
+      try {
+        const answersParam = searchParams.get("answers");
+        if (!answersParam) {
+          setLoading(false);
+          return;
+        }
 
-  const strongCoverage = coreComponents.length
-    ? coreComponents.filter((item) => item.achieved >= 0.55).length / coreComponents.length
-    : 0;
+        const parsed = JSON.parse(answersParam) as Partial<QuestionnaireAnswers>;
+        const sanitized = sanitizeAnswers(parsed);
+        setAnswers(sanitized);
 
-  if (coreComponents.length >= 3 && strongCoverage >= 0.66) {
-    addComponent("synergy", WEIGHTS.synergy, 1, TEXT.synergy);
-  }
+        const allPerfumes = await getPerfumes();
+        const ranked = rankPerfumes(allPerfumes, sanitized, 6);
+        setRecommendations(ranked);
+      } catch (error) {
+        console.error("Error generating recommendations:", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    generate();
+  }, [searchParams]);
 
-  if (coreComponents.length > 0 && strongCoverage < 0.4) {
-    addPenalty(
-      PENALTY_WEIGHTS.weakCoverage,
-      1 - strongCoverage,
-      TEXT.weakCoverage
+  const summaryChips = useMemo(() => buildSummary(answers), [answers]);
+
+  const answersQuery = useMemo(() => {
+    if (!answers) return null;
+    return new URLSearchParams({ answers: JSON.stringify(answers) }).toString();
+  }, [answers]);
+
+  if (loading) {
+    return (
+      <div className="relative flex h-screen items-center justify-center">
+        <AnimatedBackground />
+        <div className="relative z-10 loader-orbit" role="status" aria-label={TEXT.loading} />
+      </div>
     );
   }
 
-  const positiveScore = components.reduce(
-    (sum, item) => sum + item.weight * item.achieved,
-    0
-  );
-  const rawScore = Math.max(0, positiveScore - penaltyScore);
-  const matchPercentage = Math.max(0, Math.min(100, Math.round((rawScore / maxScore) * 100)));
-  const distinctReasons = Array.from(new Set(reasons)).slice(0, 4);
-
-  return { ...perfume, score: rawScore, maxScore, matchPercentage, reasons: distinctReasons };
-};
-
- type CompactMode = "normal" | "tight" | "ultra";
-
- const CARD_IMAGE_HEIGHT: Record<CompactMode, string> = {
-   normal: "min(26vh, 180px)",
-   tight: "min(22vh, 150px)",
-   ultra: "min(18vh, 120px)",
- };
-
- const CARD_BADGE_LIMIT: Record<CompactMode, number> = {
-   normal: 3,
-   tight: 2,
-   ultra: 1,
- };
-
- const CARD_REASON_LIMIT: Record<CompactMode, number> = {
-   normal: 2,
-   tight: 1,
-   ultra: 0,
- };
-
- const MatchCard = ({
-   perfume,
-   order,
-   compact = "normal",
- }: {
-   perfume: RankedPerfume;
-   order: number;
-   compact?: CompactMode;
- }) => {
-   const title = perfume.nameFa && perfume.nameFa.trim().length > 0 ? perfume.nameFa : perfume.nameEn;
-   const subtitle = [perfume.brand, perfume.collection]
-     .filter((value): value is string => !!value && value.trim().length > 0)
-     .join(" • ");
-
-   const imageHeight = CARD_IMAGE_HEIGHT[compact];
-   const badgeLimit = CARD_BADGE_LIMIT[compact];
-   const reasonLimit = CARD_REASON_LIMIT[compact];
-
-   const badges = [perfume.family, perfume.character, perfume.season, perfume.gender]
-     .filter((value): value is string => !!value && value.trim().length > 0)
-     .slice(0, badgeLimit);
-
-   const reasons = reasonLimit > 0 ? perfume.reasons.slice(0, reasonLimit) : [];
-
-   const articleRef = React.useRef<HTMLDivElement>(null);
-   const emitRipple = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-     const node = articleRef.current;
-     if (!node) return;
-     const rect = node.getBoundingClientRect();
-     const ripple = (TouchRipple as unknown as { emit?: (x: number, y: number) => void }).emit;
-     ripple?.(event.clientX - rect.left, event.clientY - rect.top);
-   }, []);
-
-   return (
-     <article
-       ref={articleRef}
-       role="button"
-       tabIndex={0}
-       onPointerDown={emitRipple}
-       aria-label={`${title ?? ""} - درصد تطابق ${perfume.matchPercentage}`}
-       className="interactive-card glass-card relative flex h-full flex-col justify-between rounded-2xl p-4 text-right animate-fade-in-up tap-highlight touch-target"
-     >
-       <TouchRipple />
-       <header className="flex items-start justify-between">
-         <span className="rounded-full bg-soft px-3 py-1 text-xs font-semibold text-muted">{order}</span>
-         <span className="text-sm font-semibold text-[var(--color-accent)]">{perfume.matchPercentage}%</span>
-       </header>
-
-       {perfume.image && (
-         <div className="flex-grow flex justify-center my-2">
-           <div
-             className="relative w-full flex-grow overflow-hidden rounded-2xl bg-white/10 backdrop-blur-sm"
-             style={{ height: imageHeight }}
-           >
-             <Image
-               src={perfume.image}
-               alt={title}
-               fill
-               className="object-contain"
-               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-               priority
-             />
-           </div>
-         </div>
-       )}
-
-       <div className="space-y-1">
-         <h3 className={`font-semibold text-[var(--color-foreground)] ${compact === "ultra" ? "text-lg" : "text-xl"} line-clamp-1`}>
-           {title}
-         </h3>
-         {compact !== "ultra" && perfume.nameEn && (
-           <p className="m-0 text-xs italic text-subtle line-clamp-1">{perfume.nameEn}</p>
-         )}
-         {compact === "normal" && subtitle && (
-           <p className="m-0 text-xs text-muted line-clamp-1">{subtitle}</p>
-         )}
-       </div>
-
-       {badges.length > 0 && (
-         <div className="flex flex-wrap justify-end gap-2 text-[10px] sm:text-xs text-muted">
-           {badges.map((badge, index) => (
-             <span key={index} className="badge-soft">
-               {badge}
-             </span>
-           ))}
-         </div>
-       )}
-
-       {reasons.length > 0 && (
-         <ul className="mt-3 space-y-1 text-[11px] sm:text-xs text-muted">
-           {reasons.map((reason, index) => (
-             <li key={index} className="line-clamp-2">
-               {reason}
-             </li>
-           ))}
-         </ul>
-       )}
-     </article>
-   );
- };
-
- function RecommendationsContent() {
-   const searchParams = useSearchParams();
-   const [recommendations, setRecommendations] = useState<RankedPerfume[]>([]);
-   const [loading, setLoading] = useState(true);
-   const [answers, setAnswers] = useState<QuestionnaireAnswers | null>(null);
-   const [compact, setCompact] = useState<CompactMode>("normal");
-
-   useEffect(() => {
-     if (typeof window === "undefined") return;
-     const evaluate = () => {
-       const height = window.innerHeight;
-       if (height < 720) setCompact("ultra");
-       else if (height < 880) setCompact("tight");
-       else setCompact("normal");
-     };
-     evaluate();
-     window.addEventListener("resize", evaluate);
-     return () => window.removeEventListener("resize", evaluate);
-   }, []);
-
-   useEffect(() => {
-     async function generate() {
-       try {
-         const answersParam = searchParams.get("answers");
-         if (!answersParam) {
-           setLoading(false);
-           return;
-         }
-         const userAnswers = JSON.parse(answersParam) as QuestionnaireAnswers;
-         setAnswers(userAnswers);
-         const allPerfumes = await getPerfumes();
-         const ranked = allPerfumes
-           .map((perfume) => computeScore(perfume, userAnswers))
-           .filter((item): item is RankedPerfume => item !== null)
-           .sort((a, b) => b.matchPercentage - a.matchPercentage || b.score - a.score)
-           .slice(0, 6)
-           .map((item) => ({
-             ...item,
-             matchPercentage: Math.min(100, Math.max(0, item.matchPercentage)),
-           }));
-         setRecommendations(ranked);
-       } catch (error) {
-         console.error("Error generating recommendations:", error);
-       } finally {
-         setLoading(false);
-       }
-     }
-     generate();
-   }, [searchParams]);
-
-   if (loading) {
-     return (
-       <div className="relative flex h-screen items-center justify-center">
-         <AnimatedBackground />
-         <div className="relative z-10 loader-orbit" role="status" aria-label={TEXT.loading} />
-       </div>
-     );
-   }
-
-   if (!answers) {
-     return (
-       <div className="relative flex h-screen flex-col items-center justify-center gap-4 px-6 text-center">
-         <AnimatedBackground />
-         <div className="relative z-10 bg-white/10 backdrop-blur-[32px] border border-white/20 rounded-3xl p-8">
+  if (!answers) {
+    return (
+      <div className="relative flex h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+        <AnimatedBackground />
+        <div className="relative z-10 rounded-3xl border border-white/20 bg-white/10 p-8 backdrop-blur-[32px]">
           <p className="text-base font-semibold text-[var(--color-foreground)]">{TEXT.noAnswers}</p>
           <Link href="/questionnaire" className="btn tap-highlight touch-target touch-feedback">
             {TEXT.startQuestionnaire}
-           </Link>
-         </div>
-       </div>
-     );
-   }
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
-   return (
-     <div className="relative flex h-screen w-full items-center justify-center px-4 lg:px-8">
-       <AnimatedBackground />
-       <div className="relative flex h-[92vh] w-full max-w-[1400px] flex-col gap-6 rounded-3xl glass-deep px-6 py-6 shadow-2xl animate-blur-in">
-         <header className="flex items-center justify-between animate-slide-in-right">
-           <h1 className="text-3xl font-semibold text-[var(--color-foreground)]">{TEXT.heading}</h1>
-         </header>
+  return (
+    <div className="relative flex h-screen w-full items-center justify-center px-4 lg:px-8">
+      <AnimatedBackground />
+      <div className="relative flex h-[92vh] w-full max-w-[1400px] flex-col gap-6 overflow-hidden rounded-3xl glass-deep px-6 py-6 shadow-2xl animate-blur-in">
+        <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between animate-slide-in-right">
+          <div className="space-y-1 text-right">
+            <h1 className="text-3xl font-semibold text-[var(--color-foreground)]">{TEXT.heading}</h1>
+            {summaryChips.length > 0 && (
+              <div className="flex flex-wrap justify-end gap-2 text-xs text-muted">
+                <span className="rounded-full border border-white/25 px-3 py-1 font-semibold text-[var(--color-accent)]">
+                  {TEXT.summaryHeading}
+                </span>
+                {summaryChips.map((chip, index) => (
+                  <span key={index} className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs">
+                    {chip}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center justify-end gap-3">
+            {answersQuery && (
+              <Link
+                href={`/questionnaire?${answersQuery}`}
+                className="btn-ghost tap-highlight touch-target touch-feedback"
+              >
+                {TEXT.refine}
+              </Link>
+            )}
+            <Link href="/questionnaire" className="btn tap-highlight touch-target touch-feedback">
+              {TEXT.restart}
+            </Link>
+          </div>
+        </header>
 
-         <section className="grid flex-1 grid-cols-3 grid-rows-2 auto-rows-fr gap-3 xl:gap-4 animate-scale-in animate-delay-2">
-           {recommendations.length > 0 ? (
-             recommendations.map((perfume, index) => (
-               <div key={perfume.id} className={`h-full animate-fade-in-up animate-delay-${Math.min(index + 3, 5)}`}>
-                 <MatchCard perfume={perfume} order={index + 1} compact={compact} />
-               </div>
-             ))
-           ) : (
-             <div className="glass-surface col-span-full flex h-full items-center justify-center rounded-3xl text-sm text-muted animate-fade-in-up animate-delay-3">
-               {TEXT.empty}
-             </div>
-           )}
-         </section>
-       </div>
-     </div>
-   );
- }
+        <section className="grid flex-1 auto-rows-fr gap-3 sm:grid-cols-2 xl:grid-cols-3 animate-scale-in animate-delay-2">
+          {recommendations.length > 0 ? (
+            recommendations.map((perfume, index) => {
+              const matchPercentLabel = `${toPersianNumbers(String(perfume.matchPercentage))}%`;
+              const matchQuality = describeMatchQuality(perfume.matchPercentage);
+              const coveragePercent = Math.round(perfume.coverage * 100);
+              const coverageLabel = `${TEXT.coverage}: ${toPersianNumbers(String(coveragePercent))}%`;
+              const intensityLabel = TEXT.intensity[perfume.intensityLevel as IntensityKey] ?? "";
+              const reasonMessages = perfume.reasons
+                .map(formatReason)
+                .filter((item): item is DisplayReason => item !== null);
 
- export default function RecommendationsPage() {
-   return (
-     <Suspense
-       fallback={
-         <div className="relative flex h-screen items-center justify-center">
-           <AnimatedBackground />
-           <div className="relative z-10 loader-orbit" role="status" aria-label={TEXT.loading} />
-         </div>
-       }
-     >
-       <RecommendationsContent />
-     </Suspense>
-   );
- }
+              return (
+                <div key={perfume.id} className={`h-full animate-fade-in-up animate-delay-${Math.min(index + 3, 5)}`}>
+                  <MatchCard
+                    perfume={perfume}
+                    order={index + 1}
+                    compact={compact}
+                    reasons={reasonMessages}
+                    matchPercentLabel={matchPercentLabel}
+                    matchQuality={matchQuality}
+                    coveragePercent={coveragePercent}
+                    coverageLabel={coverageLabel}
+                    intensityLabel={intensityLabel}
+                  />
+                </div>
+              );
+            })
+          ) : (
+            <div className="glass-surface col-span-full flex h-full items-center justify-center rounded-3xl text-sm text-muted animate-fade-in-up animate-delay-3">
+              {TEXT.empty}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+const RecommendationsPage: React.FC = () => {
+  return (
+    <Suspense
+      fallback={
+        <div className="relative flex h-screen items-center justify-center">
+          <AnimatedBackground />
+          <div className="relative z-10 loader-orbit" role="status" aria-label={TEXT.loading} />
+        </div>
+      }
+    >
+      <RecommendationsContent />
+    </Suspense>
+  );
+};
+
+export default RecommendationsPage;

--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -86,25 +86,6 @@ export default function AnimatedBackground() {
     };
   };
 
-  const getClickAnimationProps = (index: number) => {
-    const time = Date.now() / 1000;
-    const seed = time + index;
-    const newX = 20 + (Math.sin(seed) * 60 + 60) / 2;
-    const newY = 20 + (Math.cos(seed * 1.3) * 60 + 60) / 2;
-
-    return {
-      animate: isAnimatingRef.current ? {
-        x: `${newX}%`,
-        y: `${newY}%`,
-        scale: [1, 1.4, 1.1, 1],
-        rotate: [0, 10, -5, 0],
-      } : {},
-      transition: {
-        duration: 2.5,
-      }
-    };
-  };
-
   return (
     <div ref={containerRef}>
       <div className="absolute inset-0 bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50"></div>

--- a/src/components/questionnaire/NavigationControls.tsx
+++ b/src/components/questionnaire/NavigationControls.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React from "react";
+
+interface NavigationControlsProps {
+  onBack: () => void;
+  onNext: () => void;
+  disableBack: boolean;
+  disableNext: boolean;
+  backLabel: string;
+  nextLabel: string;
+  helperText: string;
+  isOptional: boolean;
+}
+
+const NavigationControls: React.FC<NavigationControlsProps> = ({
+  onBack,
+  onNext,
+  disableBack,
+  disableNext,
+  backLabel,
+  nextLabel,
+  helperText,
+  isOptional,
+}) => {
+  return (
+    <footer className="flex items-center justify-between gap-3 animate-slide-in-left animate-delay-3">
+      <button
+        onClick={onBack}
+        disabled={disableBack}
+        className="btn-ghost w-32 tap-highlight touch-target touch-feedback"
+      >
+        {backLabel}
+      </button>
+      <span className="text-xs text-muted" aria-live="polite">
+        {isOptional ? (
+          <span className="text-[var(--color-accent)]">{helperText}</span>
+        ) : (
+          helperText
+        )}
+      </span>
+      <button
+        onClick={onNext}
+        disabled={disableNext}
+        className="btn w-36 tap-highlight touch-target touch-feedback"
+      >
+        {nextLabel}
+      </button>
+    </footer>
+  );
+};
+
+export default NavigationControls;

--- a/src/components/questionnaire/OptionButton.tsx
+++ b/src/components/questionnaire/OptionButton.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React from "react";
+
+import TouchRipple from "@/components/TouchRipple";
+import type { Choice } from "@/lib/kiosk-options";
+
+const BTN_BASE =
+  "group relative overflow-hidden rounded-3xl border-2 px-4 py-5 text-center text-lg font-semibold transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-transparent tap-highlight touch-target";
+
+interface OptionButtonProps {
+  option: Choice;
+  isSelected: boolean;
+  disabled?: boolean;
+  delayClass?: string;
+  onClick: () => void;
+}
+
+const OptionButton: React.FC<OptionButtonProps> = ({
+  option,
+  isSelected,
+  disabled = false,
+  delayClass = "",
+  onClick,
+}) => {
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const handlePointerDown = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      const node = buttonRef.current;
+      const ripple = (TouchRipple as unknown as { emit?: (x: number, y: number) => void }).emit;
+      if (!node || !ripple) return;
+      const rect = node.getBoundingClientRect();
+      ripple(event.clientX - rect.left, event.clientY - rect.top);
+    },
+    []
+  );
+
+  const visualState = isSelected
+    ? "border-[var(--color-accent)] bg-[var(--accent-soft)] text-[var(--color-accent)] shadow-strong"
+    : "border-white/25 bg-white/6 text-[var(--color-foreground)] hover:border-white/40 hover:bg-white/15";
+
+  return (
+    <button
+      ref={buttonRef}
+      onClick={onClick}
+      onPointerDown={handlePointerDown}
+      disabled={disabled}
+      aria-pressed={isSelected}
+      className={[
+        BTN_BASE,
+        delayClass,
+        visualState,
+        disabled ? "cursor-not-allowed opacity-55" : "active:scale-95",
+      ].join(" ")}
+    >
+      <TouchRipple />
+      <span className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-br from-white/12 to-transparent opacity-0 transition-opacity duration-200 group-aria-pressed:opacity-100 group-focus-visible:opacity-100" />
+      <span className="relative flex flex-col items-center gap-1">
+        {option.icon && <span className="text-2xl sm:text-[28px]">{option.icon}</span>}
+        <span className="text-sm font-medium leading-6 sm:text-base">{option.label}</span>
+      </span>
+    </button>
+  );
+};
+
+export default OptionButton;

--- a/src/components/questionnaire/OptionGrid.tsx
+++ b/src/components/questionnaire/OptionGrid.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+
+import OptionButton from "./OptionButton";
+import type { QuestionDefinition } from "@/lib/questionnaire";
+
+interface OptionGridProps {
+  question: QuestionDefinition;
+  selectedValues: string[];
+  onToggle: (value: string) => void;
+  emptyMessage: string;
+}
+
+const OptionGrid: React.FC<OptionGridProps> = ({
+  question,
+  selectedValues,
+  onToggle,
+  emptyMessage,
+}) => {
+  const reachedLimit =
+    question.type === "multiple" &&
+    typeof question.maxSelections === "number" &&
+    selectedValues.length >= question.maxSelections;
+
+  return (
+    <div className="grid w-full max-w-[900px] grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3">
+      {question.options.map((option, index) => {
+        const isSelected = selectedValues.includes(option.value);
+        const disabled = !isSelected && reachedLimit;
+        const delayClass = index % 3 === 1 ? "animate-delay-1" : index % 3 === 2 ? "animate-delay-2" : "animate-delay-0";
+
+        return (
+          <OptionButton
+            key={option.value}
+            option={option}
+            isSelected={isSelected}
+            disabled={disabled}
+            delayClass={delayClass}
+            onClick={() => onToggle(option.value)}
+          />
+        );
+      })}
+
+      {question.options.length === 0 && (
+        <div className="col-span-full flex h-full items-center justify-center rounded-3xl border border-white/15 bg-white/10 text-sm text-muted">
+          {emptyMessage}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OptionGrid;

--- a/src/components/questionnaire/ProgressPanel.tsx
+++ b/src/components/questionnaire/ProgressPanel.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React from "react";
+
+interface ProgressPanelProps {
+  title: string;
+  description?: string;
+  progressLabel: string;
+  progressPercent: number;
+  progressPercentLabel: string;
+  summaryHeading: string;
+  summaryChips: string[];
+  optional: boolean;
+  optionalLabel: string;
+  limitMessage?: string | null;
+  onResetCurrent?: () => void;
+  onResetAll?: () => void;
+}
+
+const ProgressPanel: React.FC<ProgressPanelProps> = ({
+  title,
+  description,
+  progressLabel,
+  progressPercent,
+  summaryHeading,
+  summaryChips,
+  optional,
+  optionalLabel,
+  limitMessage,
+  onResetCurrent,
+  onResetAll,
+  progressPercentLabel,
+}) => {
+  const hasActions = Boolean(onResetCurrent || onResetAll);
+
+  return (
+    <header className="flex flex-col gap-5 animate-slide-in-right">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2 text-right">
+          <div className="flex items-center justify-between gap-2 text-xs font-medium text-muted" aria-live="polite">
+            <span>{progressLabel}</span>
+            {optional && (
+              <span className="rounded-full border border-white/30 px-2 py-0.5 text-[11px] text-[var(--color-accent)]">
+                {optionalLabel}
+              </span>
+            )}
+          </div>
+          <h1 className="text-3xl font-semibold text-[var(--color-foreground)]">{title}</h1>
+          {description && <p className="m-0 text-sm text-muted">{description}</p>}
+          {limitMessage && (
+            <p className="m-0 text-xs text-[var(--color-accent)]" role="status">
+              {limitMessage}
+            </p>
+          )}
+        </div>
+
+        <div className="flex w-full flex-col items-end gap-2 sm:w-56">
+          <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-white/15">
+            <div
+              className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-amber-200 via-amber-300 to-orange-300 shadow-lg transition-[width] duration-500"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <span className="text-xs font-semibold text-[var(--color-accent)]">
+            {progressPercentLabel}
+          </span>
+          {hasActions && (
+            <div className="flex items-center gap-2 text-xs text-muted">
+              {onResetCurrent && (
+                <button
+                  type="button"
+                  onClick={onResetCurrent}
+                  className="btn-ghost px-3 py-1 text-xs tap-highlight touch-target"
+                >
+                  پاک کردن این سوال
+                </button>
+              )}
+              {onResetAll && (
+                <button
+                  type="button"
+                  onClick={onResetAll}
+                  className="btn-ghost px-3 py-1 text-xs tap-highlight touch-target"
+                >
+                  شروع دوباره
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {summaryChips.length > 0 && (
+        <div
+          className="flex flex-wrap justify-end gap-2 text-xs text-muted"
+          aria-live="polite"
+          aria-label={summaryHeading}
+        >
+          <span className="rounded-full border border-white/25 px-3 py-1 font-semibold text-[var(--color-accent)]">
+            {summaryHeading}
+          </span>
+          {summaryChips.map((chip, index) => (
+            <span key={index} className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs">
+              {chip}
+            </span>
+          ))}
+        </div>
+      )}
+    </header>
+  );
+};
+
+export default ProgressPanel;

--- a/src/components/recommendations/MatchCard.tsx
+++ b/src/components/recommendations/MatchCard.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+
+import TouchRipple from "@/components/TouchRipple";
+import type { MatchQuality, RankedPerfume } from "@/lib/recommendation-engine";
+
+export type CompactMode = "normal" | "tight" | "ultra";
+
+export interface DisplayReason {
+  text: string;
+  tone: "positive" | "warning";
+}
+
+interface MatchCardProps {
+  perfume: RankedPerfume;
+  order: number;
+  compact?: CompactMode;
+  reasons: DisplayReason[];
+  matchPercentLabel: string;
+  matchQuality: MatchQuality;
+  coveragePercent: number;
+  coverageLabel: string;
+  intensityLabel: string;
+}
+
+const CARD_IMAGE_HEIGHT: Record<CompactMode, string> = {
+  normal: "min(26vh, 180px)",
+  tight: "min(22vh, 150px)",
+  ultra: "min(18vh, 120px)",
+};
+
+const CARD_BADGE_LIMIT: Record<CompactMode, number> = {
+  normal: 3,
+  tight: 2,
+  ultra: 1,
+};
+
+const CARD_REASON_LIMIT: Record<CompactMode, number> = {
+  normal: 3,
+  tight: 2,
+  ultra: 1,
+};
+
+const QUALITY_TONE_CLASS: Record<MatchQuality["tone"], string> = {
+  great: "text-emerald-300",
+  good: "text-amber-200",
+  fair: "text-sky-200",
+  light: "text-muted",
+};
+
+const REASON_TONE_CLASS: Record<DisplayReason["tone"], string> = {
+  positive: "text-muted",
+  warning: "text-rose-200",
+};
+
+const MatchCard: React.FC<MatchCardProps> = ({
+  perfume,
+  order,
+  compact = "normal",
+  reasons,
+  matchPercentLabel,
+  matchQuality,
+  coveragePercent,
+  coverageLabel,
+  intensityLabel,
+}) => {
+  const title = perfume.nameFa && perfume.nameFa.trim().length > 0 ? perfume.nameFa : perfume.nameEn;
+  const subtitle = [perfume.brand, perfume.collection]
+    .filter((value): value is string => !!value && value.trim().length > 0)
+    .join(" • ");
+
+  const imageHeight = CARD_IMAGE_HEIGHT[compact];
+  const badgeLimit = CARD_BADGE_LIMIT[compact];
+  const reasonLimit = CARD_REASON_LIMIT[compact];
+
+  const badges = [perfume.family, perfume.character, perfume.season, intensityLabel]
+    .filter((value): value is string => !!value && value.trim().length > 0)
+    .slice(0, badgeLimit);
+
+  const visibleReasons = reasons.slice(0, reasonLimit);
+  const notePreview = perfume.allNotes.slice(0, compact === "ultra" ? 2 : 4);
+
+  const articleRef = React.useRef<HTMLDivElement>(null);
+  const emitRipple = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const node = articleRef.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    const ripple = (TouchRipple as unknown as { emit?: (x: number, y: number) => void }).emit;
+    ripple?.(event.clientX - rect.left, event.clientY - rect.top);
+  }, []);
+
+  return (
+    <article
+      ref={articleRef}
+      role="button"
+      tabIndex={0}
+      onPointerDown={emitRipple}
+      aria-label={`${title ?? ""} - درصد تطابق ${matchPercentLabel}`}
+      className="interactive-card glass-card relative flex h-full flex-col justify-between rounded-2xl p-4 text-right animate-fade-in-up tap-highlight touch-target"
+    >
+      <TouchRipple />
+      <header className="flex items-start justify-between">
+        <span className="rounded-full bg-soft px-3 py-1 text-xs font-semibold text-muted">{order}</span>
+        <div className="text-right">
+          <span className="block text-sm font-semibold text-[var(--color-accent)]">{matchPercentLabel}</span>
+          <span className={`text-[11px] font-medium ${QUALITY_TONE_CLASS[matchQuality.tone]}`}>
+            {matchQuality.label}
+          </span>
+        </div>
+      </header>
+
+      {perfume.image && (
+        <div className="my-2 flex flex-grow justify-center">
+          <div className="relative w-full flex-grow overflow-hidden rounded-2xl bg-white/10 backdrop-blur-sm" style={{ height: imageHeight }}>
+            <Image
+              src={perfume.image}
+              alt={title}
+              fill
+              className="object-contain"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              priority
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <h3 className={`font-semibold text-[var(--color-foreground)] ${compact === "ultra" ? "text-lg" : "text-xl"} line-clamp-1`}>
+          {title}
+        </h3>
+        {compact !== "ultra" && perfume.nameEn && (
+          <p className="m-0 text-xs italic text-subtle line-clamp-1">{perfume.nameEn}</p>
+        )}
+        {compact === "normal" && subtitle && (
+          <p className="m-0 text-xs text-muted line-clamp-1">{subtitle}</p>
+        )}
+      </div>
+
+      {badges.length > 0 && (
+        <div className="mt-2 flex flex-wrap justify-end gap-2 text-[10px] sm:text-xs text-muted">
+          {badges.map((badge, index) => (
+            <span key={index} className="badge-soft">
+              {badge}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-3 space-y-1">
+        <div className="flex items-center justify-between text-[11px] text-muted">
+          <span>{coverageLabel}</span>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-amber-200 via-amber-300 to-orange-300"
+            style={{ width: `${coveragePercent}%` }}
+          />
+        </div>
+      </div>
+
+      {visibleReasons.length > 0 && (
+        <ul className="mt-3 space-y-1 text-[11px] sm:text-xs">
+          {visibleReasons.map((reason, index) => (
+            <li key={index} className={`line-clamp-2 ${REASON_TONE_CLASS[reason.tone]}`}>
+              {reason.text}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {notePreview.length > 0 && (
+        <div className="mt-3 flex flex-wrap justify-end gap-2 text-[10px] sm:text-xs text-muted">
+          {notePreview.map((note, index) => (
+            <span key={index} className="rounded-full border border-white/15 bg-white/8 px-2.5 py-1">
+              {note}
+            </span>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+};
+
+export default MatchCard;

--- a/src/lib/questionnaire.ts
+++ b/src/lib/questionnaire.ts
@@ -1,0 +1,230 @@
+import {
+  Choice,
+  INTENSITY_CHOICES,
+  MOMENT_CHOICES,
+  MOOD_CHOICES,
+  NOTE_CHOICES,
+  STYLE_CHOICES,
+  TIME_CHOICES,
+  LABEL_LOOKUP,
+} from "./kiosk-options";
+
+export type QuestionType = "multiple" | "single";
+
+export interface QuestionnaireAnswers {
+  moods: string[];
+  moments: string[];
+  times: string[];
+  intensity: string[];
+  styles: string[];
+  noteLikes: string[];
+  noteDislikes: string[];
+}
+
+export interface QuestionDefinition {
+  title: string;
+  description?: string;
+  type: QuestionType;
+  options: Choice[];
+  key: keyof QuestionnaireAnswers;
+  optional?: boolean;
+  maxSelections?: number;
+}
+
+export const TEXT = {
+  progressPrefix: "سوال",
+  progressOf: "از",
+  optional: "اختیاری",
+  requiredHint: "برای ادامه لطفاً یک گزینه را انتخاب کنید.",
+  back: "بازگشت",
+  next: "بعدی",
+  finish: "مشاهده پیشنهادات",
+  noOptions: "موردی در دسترس نیست.",
+  summaryHeading: "گزینه‌های انتخابی",
+  separator: "، ",
+  summaryLabels: {
+    moods: "حال‌وهوا",
+    moments: "موقعیت",
+    times: "زمان",
+    intensity: "شدت",
+    styles: "سبک",
+    likes: "نُت‌های محبوب",
+    dislikes: "نُت‌های نامطلوب",
+  },
+  questions: {
+    moods: {
+      title: "حال‌وهواهای مورد علاقه شما چیست؟",
+      description: "حداکثر دو مورد را انتخاب کنید.",
+    },
+    moments: {
+      title: "این عطر را بیشتر برای چه موقعیت‌هایی می‌خواهید؟",
+      description: "حداکثر سه مورد را انتخاب کنید.",
+    },
+    times: {
+      title: "بیشتر برای چه زمانی از روز؟",
+    },
+    intensity: {
+      title: "شدت پخش بو را ترجیح می‌دهید؟",
+      description: "از ملایم تا قوی.",
+    },
+    styles: {
+      title: "سبک عطر مورد علاقه شما چیست؟",
+    },
+    likes: {
+      title: "به کدام دسته از نُت‌ها علاقه دارید؟",
+      description: "اختیاری؛ تا سه مورد.",
+    },
+    dislikes: {
+      title: "از کدام دسته از نُت‌ها خوشتان نمی‌آید؟",
+      description: "اختیاری؛ تا سه مورد.",
+    },
+  },
+};
+
+export const QUESTION_CONFIG: QuestionDefinition[] = [
+  {
+    key: "moods",
+    type: "multiple",
+    options: MOOD_CHOICES,
+    title: TEXT.questions.moods.title,
+    description: TEXT.questions.moods.description,
+    maxSelections: 2,
+  },
+  {
+    key: "moments",
+    type: "multiple",
+    options: MOMENT_CHOICES,
+    title: TEXT.questions.moments.title,
+    description: TEXT.questions.moments.description,
+    maxSelections: 3,
+  },
+  {
+    key: "times",
+    type: "single",
+    options: TIME_CHOICES,
+    title: TEXT.questions.times.title,
+  },
+  {
+    key: "intensity",
+    type: "single",
+    options: INTENSITY_CHOICES,
+    title: TEXT.questions.intensity.title,
+    description: TEXT.questions.intensity.description,
+  },
+  {
+    key: "styles",
+    type: "single",
+    options: STYLE_CHOICES,
+    title: TEXT.questions.styles.title,
+  },
+  {
+    key: "noteLikes",
+    type: "multiple",
+    options: NOTE_CHOICES,
+    title: TEXT.questions.likes.title,
+    description: TEXT.questions.likes.description,
+    optional: true,
+    maxSelections: 3,
+  },
+  {
+    key: "noteDislikes",
+    type: "multiple",
+    options: NOTE_CHOICES,
+    title: TEXT.questions.dislikes.title,
+    description: TEXT.questions.dislikes.description,
+    optional: true,
+    maxSelections: 3,
+  },
+];
+
+export const SUMMARY_PREVIEW_LIMIT = 4;
+
+export const initialAnswers = (): QuestionnaireAnswers => ({
+  moods: [],
+  moments: [],
+  times: [],
+  intensity: [],
+  styles: [],
+  noteLikes: [],
+  noteDislikes: [],
+});
+
+export const separatorJoin = (values: string[]) =>
+  values
+    .map((value) => LABEL_LOOKUP[value] ?? value)
+    .filter((value) => value.trim().length > 0)
+    .join(TEXT.separator);
+
+export const sanitizeAnswers = (
+  input: Partial<QuestionnaireAnswers> | null | undefined
+): QuestionnaireAnswers => {
+  const base = initialAnswers();
+
+  if (!input || typeof input !== "object") {
+    return base;
+  }
+
+  const unique = <T extends string>(items: T[]): T[] => {
+    const seen = new Set<T>();
+    const ordered: T[] = [];
+    items.forEach((item) => {
+      if (!seen.has(item)) {
+        ordered.push(item);
+        seen.add(item);
+      }
+    });
+    return ordered;
+  };
+
+  for (const question of QUESTION_CONFIG) {
+    const raw = input[question.key];
+    if (!Array.isArray(raw)) {
+      continue;
+    }
+
+    const optionValues = new Set(question.options.map((option) => option.value));
+    const cleaned = unique(
+      raw
+        .map((value) => (typeof value === "string" ? value.trim() : ""))
+        .filter((value) => value.length > 0 && optionValues.has(value))
+    );
+
+    if (question.type === "single") {
+      base[question.key] = cleaned.slice(0, 1);
+      continue;
+    }
+
+    if (typeof question.maxSelections === "number") {
+      base[question.key] = cleaned.slice(0, question.maxSelections);
+    } else {
+      base[question.key] = cleaned;
+    }
+  }
+
+  return base;
+};
+
+export const areAnswersEqual = (
+  a: QuestionnaireAnswers,
+  b: QuestionnaireAnswers
+) => {
+  return (
+    QUESTION_CONFIG.every((question) => {
+      const key = question.key;
+      const left = a[key];
+      const right = b[key];
+      return (
+        left.length === right.length &&
+        left.every((value, index) => value === right[index])
+      );
+    })
+  );
+};
+
+export const firstIncompleteStep = (answers: QuestionnaireAnswers) => {
+  const index = QUESTION_CONFIG.findIndex((question) => {
+    const selected = answers[question.key];
+    return !question.optional && selected.length === 0;
+  });
+  return index === -1 ? 0 : index;
+};

--- a/src/lib/recommendation-engine.ts
+++ b/src/lib/recommendation-engine.ts
@@ -1,0 +1,474 @@
+import type { Perfume } from "./api";
+import { NOTE_CHOICES } from "./kiosk-options";
+import type { QuestionnaireAnswers } from "./questionnaire";
+
+export type MatchIntensity = "light" | "medium" | "strong";
+
+export type MatchReasonCode =
+  | "mood"
+  | "moment"
+  | "time"
+  | "intensity"
+  | "style"
+  | "note"
+  | "synergy"
+  | "dislikePenalty"
+  | "coveragePenalty";
+
+export interface MatchReason {
+  code: MatchReasonCode;
+  value?: string;
+  tone: "positive" | "warning";
+}
+
+export interface RankedPerfume extends Perfume {
+  score: number;
+  maxScore: number;
+  matchPercentage: number;
+  reasons: MatchReason[];
+  intensityLevel: MatchIntensity;
+  coverage: number;
+}
+
+const WEIGHTS = {
+  moods: 28,
+  moments: 18,
+  times: 10,
+  intensity: 12,
+  styles: 8,
+  notes: 18,
+  synergy: 8,
+} as const;
+
+const PENALTY_WEIGHTS = {
+  dislikes: 14,
+  weakCoverage: 10,
+} as const;
+
+const STRONG_KEYWORDS = [
+  "intense",
+  "rich",
+  "deep",
+  "oud",
+  "oriental",
+  "amber",
+  "noir",
+  "night",
+  "warm",
+];
+
+const LIGHT_KEYWORDS = [
+  "light",
+  "soft",
+  "fresh",
+  "clean",
+  "citrus",
+  "airy",
+  "green",
+  "bright",
+];
+
+const NOTE_KEYWORDS: Record<string, string[]> = Object.fromEntries(
+  NOTE_CHOICES.map((choice) => [choice.value, choice.keywords])
+);
+
+const MOOD_PROFILES: Record<
+  string,
+  { families: string[]; characters: string[]; notes: string[] }
+> = {
+  fresh: {
+    families: ["fresh", "citrus", "aquatic", "green", "aromatic"],
+    characters: ["fresh", "cool", "clean", "energetic", "marine", "crisp"],
+    notes: [...(NOTE_KEYWORDS.citrus ?? []), ...(NOTE_KEYWORDS.green ?? [])],
+  },
+  sweet: {
+    families: ["gourmand", "sweet", "oriental"],
+    characters: ["sweet", "gourmand", "creamy", "dessert"],
+    notes: [...(NOTE_KEYWORDS.sweet ?? [])],
+  },
+  warm: {
+    families: ["spicy", "oriental", "amber"],
+    characters: ["warm", "spicy", "amber", "sensual"],
+    notes: [...(NOTE_KEYWORDS.spicy ?? []), ...(NOTE_KEYWORDS.oriental ?? [])],
+  },
+  floral: {
+    families: ["floral", "powdery"],
+    characters: ["floral", "soft", "romantic", "powdery"],
+    notes: [...(NOTE_KEYWORDS.floral ?? []), ...(NOTE_KEYWORDS.musky ?? [])],
+  },
+  woody: {
+    families: ["woody", "chypre", "mossy"],
+    characters: ["wood", "earthy", "classic", "smoky"],
+    notes: [...(NOTE_KEYWORDS.woody ?? []), "patchouli", "leather"],
+  },
+};
+
+const MOMENT_PROFILES: Record<
+  string,
+  {
+    seasons?: string[];
+    intensity?: Array<MatchIntensity>;
+    characters?: string[];
+    notes?: string[];
+  }
+> = {
+  daily: {
+    seasons: ["all", "cool", "warm"],
+    intensity: ["light", "medium"],
+    characters: ["fresh", "clean", "soft", "balanced"],
+  },
+  evening: {
+    seasons: ["cool", "cold"],
+    intensity: ["medium", "strong"],
+    characters: ["warm", "sweet", "intense", "sensual"],
+  },
+  outdoor: {
+    seasons: ["warm", "all"],
+    intensity: ["light", "medium"],
+    characters: ["fresh", "green", "citrus", "airy"],
+    notes: [...(NOTE_KEYWORDS.citrus ?? []), ...(NOTE_KEYWORDS.green ?? [])],
+  },
+  gift: {
+    seasons: ["all"],
+    intensity: ["light", "medium"],
+    characters: ["soft", "smooth", "elegant"],
+    notes: [...(NOTE_KEYWORDS.floral ?? []), ...(NOTE_KEYWORDS.sweet ?? [])],
+  },
+};
+
+const TIME_PROFILES: Record<
+  string,
+  { characters: string[]; intensity?: Array<MatchIntensity> }
+> = {
+  day: {
+    characters: ["fresh", "clean", "bright", "light"],
+    intensity: ["light", "medium"],
+  },
+  night: {
+    characters: ["warm", "intense", "sensual", "deep"],
+    intensity: ["medium", "strong"],
+  },
+  anytime: {
+    characters: ["versatile", "balanced"],
+  },
+};
+
+const STYLE_MAP: Record<string, string[]> = {
+  feminine: ["female"],
+  masculine: ["male"],
+  unisex: ["unisex"],
+  any: ["female", "male", "unisex"],
+};
+
+const normalize = (value?: string) => value?.toLowerCase() ?? "";
+
+const includesAny = (target: string, keywords: string[]) =>
+  keywords.some((keyword) => target.includes(keyword));
+
+const notesMatch = (notes: string[], keywords: string[]) =>
+  keywords.some((keyword) => notes.some((note) => note.includes(keyword)));
+
+const deriveIntensity = (perfume: Perfume): MatchIntensity => {
+  const base = `${perfume.character ?? ""} ${perfume.family ?? ""}`.toLowerCase();
+  if (STRONG_KEYWORDS.some((keyword) => base.includes(keyword))) return "strong";
+  if (LIGHT_KEYWORDS.some((keyword) => base.includes(keyword))) return "light";
+  const noteCount = perfume.allNotes.length;
+  if (noteCount >= 9) return "strong";
+  if (noteCount <= 4) return "light";
+  return "medium";
+};
+
+const mapSeason = (season?: string) => {
+  const normalized = normalize(season);
+  if (normalized.includes("warm")) return "warm";
+  if (normalized.includes("cold")) return "cold";
+  if (normalized.includes("cool")) return "cool";
+  return "all";
+};
+
+const moodScore = (perfume: Perfume, value: string, notes: string[]) => {
+  const profile = MOOD_PROFILES[value];
+  if (!profile) return 0;
+  const family = normalize(perfume.family);
+  const character = normalize(perfume.character);
+  let score = 0;
+  if (includesAny(family, profile.families)) score += 0.4;
+  if (includesAny(character, profile.characters)) score += 0.4;
+  if (notesMatch(notes, profile.notes)) score += 0.2;
+  return score;
+};
+
+const momentScore = (
+  perfume: Perfume,
+  value: string,
+  intensity: MatchIntensity,
+  notes: string[]
+) => {
+  const profile = MOMENT_PROFILES[value];
+  if (!profile) return 0;
+  const seasonMatch = profile.seasons?.includes(mapSeason(perfume.season)) ? 0.4 : 0;
+  const intensityMatch = profile.intensity?.includes(intensity) ? 0.3 : 0;
+  const characterMatch =
+    profile.characters && includesAny(normalize(perfume.character), profile.characters)
+      ? 0.2
+      : 0;
+  const noteMatch = profile.notes && notesMatch(notes, profile.notes) ? 0.1 : 0;
+  return seasonMatch + intensityMatch + characterMatch + noteMatch;
+};
+
+const timeScore = (
+  perfume: Perfume,
+  value: string,
+  intensity: MatchIntensity
+) => {
+  const profile = TIME_PROFILES[value];
+  if (!profile) return 0;
+  const charMatch = includesAny(normalize(perfume.character), profile.characters) ? 0.6 : 0;
+  const intensityMatch = profile.intensity?.includes(intensity) ? 0.4 : 0;
+  return charMatch + intensityMatch;
+};
+
+const intensityScore = (perfumeIntensity: MatchIntensity, desired: string[]) => {
+  if (desired.length === 0) return 0;
+  const wanted = desired[0];
+  if (wanted === perfumeIntensity) return 1;
+  if (wanted === "medium" || perfumeIntensity === "medium") return 0.6;
+  return 0.2;
+};
+
+const styleScore = (perfume: Perfume, styles: string[]) => {
+  if (styles.length === 0) return 0;
+  const gender = normalize(perfume.gender);
+  const preferred = STYLE_MAP[styles[0]] ?? STYLE_MAP.any;
+  return preferred.includes(gender) ? 1 : 0.3;
+};
+
+const notePreferenceScore = (
+  notes: string[],
+  desired: string[]
+): { score: number; best: string | null } => {
+  if (desired.length === 0) return { score: 0, best: null };
+  let matches = 0;
+  let bestValue: string | null = null;
+  let bestHits = -1;
+  for (const value of desired) {
+    const keywords = NOTE_KEYWORDS[value] ?? [];
+    const hits = keywords.filter((keyword) => notes.some((note) => note.includes(keyword))).length;
+    if (hits > 0) {
+      matches += 1;
+      if (hits > bestHits) {
+        bestHits = hits;
+        bestValue = value;
+      }
+    }
+  }
+  return { score: matches / desired.length, best: bestValue };
+};
+
+const dislikedMatches = (notes: string[], dislikes: string[]) =>
+  dislikes.reduce((total, value) => {
+    const keywords = NOTE_KEYWORDS[value] ?? [];
+    const hits = keywords.filter((keyword) => notes.some((note) => note.includes(keyword))).length;
+    return total + hits;
+  }, 0);
+
+type ComponentId = keyof typeof WEIGHTS | "notes";
+
+const computeScore = (
+  perfume: Perfume,
+  answers: QuestionnaireAnswers
+): RankedPerfume | null => {
+  const notes = perfume.allNotes.map((note) => note.toLowerCase());
+  const dislikeHits = dislikedMatches(notes, answers.noteDislikes);
+
+  const components: Array<{
+    id: ComponentId;
+    weight: number;
+    achieved: number;
+    reason?: MatchReason;
+  }> = [];
+  let penaltyScore = 0;
+  const reasons: MatchReason[] = [];
+  const perfumeIntensity = deriveIntensity(perfume);
+
+  const addReason = (reason?: MatchReason, achieved?: number) => {
+    if (!reason) return;
+    if (reason.tone === "positive" && typeof achieved === "number" && achieved < 0.55) {
+      return;
+    }
+    const key = `${reason.code}:${reason.value ?? ""}`;
+    const exists = reasons.some((item) => `${item.code}:${item.value ?? ""}` === key);
+    if (!exists) {
+      reasons.push(reason);
+    }
+  };
+
+  const addComponent = (
+    id: ComponentId,
+    weight: number,
+    achieved: number,
+    reason?: MatchReason
+  ) => {
+    components.push({ id, weight, achieved, reason });
+    addReason(reason, achieved);
+  };
+
+  const addPenalty = (weight: number, severity: number, reason?: MatchReason) => {
+    penaltyScore += weight * Math.min(Math.max(severity, 0), 1);
+    if (reason) {
+      const tagged = { ...reason, tone: "warning" as const };
+      const key = `${tagged.code}:${tagged.value ?? ""}`;
+      const exists = reasons.some((item) => `${item.code}:${item.value ?? ""}` === key);
+      if (!exists) {
+        reasons.push(tagged);
+      }
+    }
+  };
+
+  if (answers.moods.length) {
+    let total = 0;
+    let strongestValue: string | null = null;
+    let strongestRatio = 0;
+    answers.moods.forEach((value) => {
+      const ratio = moodScore(perfume, value, notes);
+      total += ratio;
+      if (ratio > strongestRatio) {
+        strongestRatio = ratio;
+        strongestValue = value;
+      }
+    });
+    const achieved = total / answers.moods.length;
+    const reason =
+      strongestValue && strongestRatio >= 0.55
+        ? { code: "mood" as const, value: strongestValue, tone: "positive" as const }
+        : undefined;
+    addComponent("moods", WEIGHTS.moods, achieved, reason);
+  }
+
+  if (answers.moments.length) {
+    let total = 0;
+    let strongestValue: string | null = null;
+    let strongestRatio = 0;
+    answers.moments.forEach((value) => {
+      const ratio = momentScore(perfume, value, perfumeIntensity, notes);
+      total += ratio;
+      if (ratio > strongestRatio) {
+        strongestRatio = ratio;
+        strongestValue = value;
+      }
+    });
+    const achieved = total / answers.moments.length;
+    const reason =
+      strongestValue && strongestRatio >= 0.5
+        ? { code: "moment" as const, value: strongestValue, tone: "positive" as const }
+        : undefined;
+    addComponent("moments", WEIGHTS.moments, achieved, reason);
+  }
+
+  if (answers.times.length) {
+    const ratio = timeScore(perfume, answers.times[0], perfumeIntensity);
+    const reason =
+      ratio >= 0.55
+        ? { code: "time" as const, value: answers.times[0], tone: "positive" as const }
+        : undefined;
+    addComponent("times", WEIGHTS.times, ratio, reason);
+  }
+
+  if (answers.intensity.length) {
+    const ratio = intensityScore(perfumeIntensity, answers.intensity);
+    const reason =
+      ratio >= 0.6
+        ? { code: "intensity" as const, value: answers.intensity[0], tone: "positive" as const }
+        : undefined;
+    addComponent("intensity", WEIGHTS.intensity, ratio, reason);
+  }
+
+  if (answers.styles.length) {
+    const ratio = styleScore(perfume, answers.styles);
+    const reason =
+      ratio >= 0.7
+        ? { code: "style" as const, value: answers.styles[0], tone: "positive" as const }
+        : undefined;
+    addComponent("styles", WEIGHTS.styles, ratio, reason);
+  }
+
+  if (answers.noteLikes.length) {
+    const noteFeedback = notePreferenceScore(notes, answers.noteLikes);
+    const reason = noteFeedback.best
+      ? { code: "note" as const, value: noteFeedback.best, tone: "positive" as const }
+      : undefined;
+    addComponent("notes", WEIGHTS.notes, noteFeedback.score, reason);
+  }
+
+  if (dislikeHits > 0) {
+    const severity = Math.min(dislikeHits / 3, 1);
+    addPenalty(PENALTY_WEIGHTS.dislikes, severity, { code: "dislikePenalty", tone: "warning" });
+  }
+
+  const maxScore = components.reduce((sum, item) => sum + item.weight, 0);
+  if (maxScore === 0) {
+    return {
+      ...perfume,
+      score: 0,
+      maxScore: 0,
+      matchPercentage: 0,
+      reasons: [],
+      intensityLevel: perfumeIntensity,
+      coverage: 0,
+    };
+  }
+
+  const coreComponents = components.filter((item) =>
+    ["moods", "moments", "times", "intensity", "styles"].includes(item.id)
+  );
+
+  const strongCoverage = coreComponents.length
+    ? coreComponents.filter((item) => item.achieved >= 0.55).length / coreComponents.length
+    : 0;
+
+  if (coreComponents.length >= 3 && strongCoverage >= 0.66) {
+    addComponent("synergy", WEIGHTS.synergy, 1, { code: "synergy", tone: "positive" });
+  }
+
+  if (coreComponents.length > 0 && strongCoverage < 0.4) {
+    addPenalty(PENALTY_WEIGHTS.weakCoverage, 1 - strongCoverage, {
+      code: "coveragePenalty",
+      tone: "warning",
+    });
+  }
+
+  const positiveScore = components.reduce((sum, item) => sum + item.weight * item.achieved, 0);
+  const rawScore = Math.max(0, positiveScore - penaltyScore);
+  const matchPercentage = Math.max(0, Math.min(100, Math.round((rawScore / maxScore) * 100)));
+
+  return {
+    ...perfume,
+    score: rawScore,
+    maxScore,
+    matchPercentage,
+    reasons,
+    intensityLevel: perfumeIntensity,
+    coverage: strongCoverage,
+  };
+};
+
+export const rankPerfumes = (
+  perfumes: Perfume[],
+  answers: QuestionnaireAnswers,
+  limit = 6
+): RankedPerfume[] => {
+  return perfumes
+    .map((perfume) => computeScore(perfume, answers))
+    .filter((item): item is RankedPerfume => item !== null)
+    .sort((a, b) => b.matchPercentage - a.matchPercentage || b.score - a.score)
+    .slice(0, Math.max(limit, 0));
+};
+
+export const describeMatchQuality = (percentage: number) => {
+  if (percentage >= 85) return { tone: "great" as const, label: "پیشنهاد عالی" };
+  if (percentage >= 65) return { tone: "good" as const, label: "پیشنهاد مناسب" };
+  if (percentage >= 45) return { tone: "fair" as const, label: "گزینه قابل بررسی" };
+  return { tone: "light" as const, label: "تطابق محدود" };
+};
+
+export type MatchQuality = ReturnType<typeof describeMatchQuality>;


### PR DESCRIPTION
## Summary
- move questionnaire configuration into a shared library and update the page to persist answers via query params, surface selection limits, and add reset actions
- add focused questionnaire UI components for the option grid, progress header, and navigation controls to simplify the main flow
- introduce a reusable recommendation engine with detailed match reasons and redesign the recommendations page with richer match cards and quick refine links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b9f377e8832096a79a7743b35a58