### PR TITLE
Revamp questionnaire flow and recommendation UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,29 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+## Development quickstart
 
-## Getting Started
-
-First, run the development server:
+Run the development server with hot reloading:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The app is available at [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Environment variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+The frontend consumes the Strapi API and needs its base URL at runtime. Create a `.env.local` file with:
 
-## Learn More
+```bash
+NEXT_PUBLIC_STRAPI_BASE_URL=http://localhost:1337
+NEXT_PUBLIC_STRAPI_TOKEN= # optional bearer token when the API requires auth
+```
 
-To learn more about Next.js, take a look at the following resources:
+You can override `NEXT_PUBLIC_STRAPI_BASE_URL` per environment without rebuilding the app. When the variable is omitted the client will default to `http://localhost:1337`.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Useful scripts
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Start Next.js in development mode. |
+| `npm run build` | Generate a production build. |
+| `npm run start` | Serve the production build. |
+| `npm run lint` | Run ESLint against the project. |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,10 +113,6 @@
     min-height: 100%;
     background-color: var(--background);
     overscroll-behavior: none;
-    -webkit-user-select: none;
-    user-select: none;
-    -webkit-touch-callout: none;
-    touch-action: manipulation;
   }
 
   body {
@@ -131,11 +127,17 @@
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     position: relative;
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   /* Kiosk-specific body adjustments */
   body.kiosk-body {
     cursor: none;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    touch-action: manipulation;
   }
 
   body::before,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,33 +4,66 @@ import Link from "next/link";
 import TapIndicator from "@/components/TapIndicator";
 import KioskFrame from "@/components/KioskFrame";
 
+const BULLETS = [
+  "۷ پرسش کوتاه بر اساس سلیقه و موقعیت شما",
+  "مرور پاسخ‌ها و ویرایش آن‌ها قبل از دیدن نتیجه",
+  "پیشنهادهای شخصی‌سازی‌شده با توضیح دلیل تطابق",
+];
+
 export default function HomePage() {
   return (
     <KioskFrame>
-      <div className="relative flex h-full w-full items-center justify-center">
-        <div className="relative flex flex-col items-center gap-8 sm:gap-10 lg:gap-12 text-center bg-white/10 backdrop-blur-[40px] border border-white/20 rounded-3xl p-8 sm:p-12 lg:p-16 w-full max-w-lg sm:max-w-2xl lg:max-w-4xl shadow-2xl animate-blur-in">
-          <div className="animate-scale-in">
+      <div className="relative flex h-full w-full items-center justify-center px-4">
+        <div className="relative flex w-full max-w-5xl flex-col gap-10 rounded-3xl border border-white/20 bg-white/10 p-8 text-center shadow-2xl backdrop-blur-[40px] animate-blur-in sm:p-12 lg:flex-row lg:items-center lg:gap-14 lg:text-right">
+          <div className="mx-auto flex w-full max-w-sm justify-center lg:order-2 lg:max-w-none">
             <Image
               src="/logo.webp"
               alt="لوگوی فروشگاه"
-              width={600}
-              height={600}
+              width={520}
+              height={520}
               priority
-              className="rounded-2xl animate-blur-in animate-delay-1"
+              className="rounded-2xl animate-scale-in"
             />
           </div>
 
-          <div className="relative animate-fade-in-up animate-delay-3">
-            <Link
-              href="/questionnaire"
-              className="btn tap-highlight touch-target touch-feedback z-10 px-8 sm:px-10 lg:px-12 py-5 sm:py-6 text-lg sm:text-xl font-medium"
-            >
-              شروع پرسشنامه
-            </Link>
-            <TapIndicator
-              className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 animate-fade-in animate-delay-4"
-              size={200}
-            />
+          <div className="flex flex-1 flex-col items-center gap-6 text-center lg:items-end lg:text-right">
+            <div className="space-y-3 animate-fade-in-up">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold text-[var(--color-accent)]">
+                رایحه‌ای متناسب با شخصیت شما
+              </span>
+              <h1 className="text-3xl font-semibold text-[var(--color-foreground)] sm:text-4xl">
+                پرسشنامه عطر را در سه دقیقه تکمیل کنید
+              </h1>
+              <p className="m-0 max-w-xl text-sm text-muted sm:text-base">
+                پاسخ به چند پرسش ساده درباره حال‌وهوا، موقعیت استفاده و نُت‌های مورد علاقه، ما را به پیشنهادهای دقیق‌تر می‌رساند.
+                در پایان می‌توانید پیش از مشاهده نتیجه، همه پاسخ‌ها را بازبینی و اصلاح کنید.
+              </p>
+            </div>
+
+            <ul className="w-full space-y-2 text-sm text-muted animate-fade-in-up animate-delay-1">
+              {BULLETS.map((item, index) => (
+                <li key={index} className="flex items-center justify-center gap-2 lg:justify-end">
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/15 text-xs font-semibold text-[var(--color-accent)]">
+                    {index + 1}
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+
+            <div className="relative flex flex-col items-center gap-2 animate-fade-in-up animate-delay-2 lg:items-end">
+              <Link
+                href="/questionnaire"
+                className="btn tap-highlight touch-target touch-feedback z-10 px-10 py-5 text-lg font-medium"
+              >
+                شروع پرسشنامه
+              </Link>
+              <span className="text-xs text-muted">میانگین زمان تکمیل کمتر از سه دقیقه است.</span>
+              <TapIndicator
+                className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 animate-fade-in animate-delay-4 lg:left-auto lg:right-6"
+                size={200}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/questionnaire/page.tsx
+++ b/src/app/questionnaire/page.tsx
@@ -5,8 +5,12 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import KioskFrame from "@/components/KioskFrame";
 import NavigationControls from "@/components/questionnaire/NavigationControls";
+import NotePreferenceGrid, {
+  type NotePreferenceValue,
+} from "@/components/questionnaire/NotePreferenceGrid";
 import OptionGrid from "@/components/questionnaire/OptionGrid";
 import ProgressPanel from "@/components/questionnaire/ProgressPanel";
+import ReviewStep from "@/components/questionnaire/ReviewStep";
 import { toPersianNumbers } from "@/lib/api";
 import {
   TEXT,
@@ -18,7 +22,46 @@ import {
   sanitizeAnswers,
   areAnswersEqual,
   firstIncompleteStep,
+  isNotePreferenceQuestion,
+  QUESTION_KEYS,
 } from "@/lib/questionnaire";
+
+const ANSWER_STORAGE_KEY = "perfume-quiz-answers-v2";
+const SETTINGS_STORAGE_KEY = "perfume-quiz-settings-v1";
+
+interface QuestionnaireSettings {
+  autoAdvanceSingle: boolean;
+}
+
+const DEFAULT_SETTINGS: QuestionnaireSettings = {
+  autoAdvanceSingle: false,
+};
+
+const readStoredAnswers = (): QuestionnaireAnswers | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(ANSWER_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<QuestionnaireAnswers>;
+    return sanitizeAnswers(parsed);
+  } catch (error) {
+    console.warn("Unable to read stored answers", error);
+    return null;
+  }
+};
+
+const readStoredSettings = (): QuestionnaireSettings => {
+  if (typeof window === "undefined") return DEFAULT_SETTINGS;
+  try {
+    const raw = window.sessionStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!raw) return DEFAULT_SETTINGS;
+    const parsed = JSON.parse(raw) as Partial<QuestionnaireSettings>;
+    return { ...DEFAULT_SETTINGS, ...parsed };
+  } catch (error) {
+    console.warn("Unable to read stored settings", error);
+    return DEFAULT_SETTINGS;
+  }
+};
 
 const Questionnaire: React.FC = () => {
   const router = useRouter();
@@ -36,57 +79,138 @@ const Questionnaire: React.FC = () => {
     }
   }, [searchParams]);
 
-  const initialState = answersFromQuery ?? initialAnswers();
+  const storedAnswers = useMemo(() => readStoredAnswers(), []);
+  const initialState = answersFromQuery ?? storedAnswers ?? initialAnswers();
   const [answers, setAnswers] = useState<QuestionnaireAnswers>(initialState);
-  const [currentStep, setCurrentStep] = useState(() => firstIncompleteStep(initialState));
+  const initialStepIndex = answersFromQuery
+    ? firstIncompleteStep(answersFromQuery)
+    : storedAnswers
+      ? firstIncompleteStep(storedAnswers)
+      : 0;
+  const [currentStep, setCurrentStep] = useState(initialStepIndex);
+  const [isReview, setIsReview] = useState(false);
+  const [settings, setSettings] = useState<QuestionnaireSettings>(() => readStoredSettings());
 
   useEffect(() => {
     if (!answersFromQuery) return;
     setAnswers((prev) => (areAnswersEqual(prev, answersFromQuery) ? prev : answersFromQuery));
     setCurrentStep(firstIncompleteStep(answersFromQuery));
+    setIsReview(false);
   }, [answersFromQuery]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.sessionStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+    } catch (error) {
+      console.warn("Failed to persist settings", error);
+    }
+  }, [settings]);
 
   const questions = QUESTION_CONFIG;
   const totalSteps = questions.length;
-  const currentQuestion = questions[currentStep];
-  const selectedValues = answers[currentQuestion.key];
+  const sanitizedAnswers = useMemo(() => sanitizeAnswers(answers), [answers]);
+  const encodedAnswers = useMemo(() => JSON.stringify(sanitizedAnswers), [sanitizedAnswers]);
 
-  const encodedAnswers = useMemo(() => JSON.stringify(answers), [answers]);
+  const searchParamsString = useMemo(() => searchParams.toString(), [searchParams]);
+  const requestedStep = useMemo(() => {
+    const value = searchParams.get("step");
+    if (!value) return null;
+    if (value === "review") return "review" as const;
+    if (/^\d+$/.test(value)) {
+      const index = Number(value);
+      if (!Number.isNaN(index)) {
+        return Math.min(Math.max(index, 0), totalSteps - 1);
+      }
+    }
+    const targetIndex = questions.findIndex((question) => question.key === value);
+    return targetIndex >= 0 ? targetIndex : null;
+  }, [questions, searchParams, totalSteps]);
+
+  useEffect(() => {
+    if (requestedStep === null) return;
+    if (requestedStep === "review") {
+      setIsReview(true);
+      return;
+    }
+    setIsReview(false);
+    setCurrentStep((prev) => (prev === requestedStep ? prev : requestedStep));
+  }, [requestedStep]);
+
   const hasAnswers = useMemo(
-    () => questions.some((question) => answers[question.key].length > 0),
-    [answers, questions]
+    () => QUESTION_KEYS.some((key) => sanitizedAnswers[key].length > 0),
+    [sanitizedAnswers]
   );
 
   useEffect(() => {
-    if (!hasAnswers) {
-      if (searchParams.get("answers")) {
-        router.replace("/questionnaire", { scroll: false });
+    if (typeof window === "undefined") return;
+    try {
+      if (hasAnswers) {
+        window.sessionStorage.setItem(ANSWER_STORAGE_KEY, encodedAnswers);
+      } else {
+        window.sessionStorage.removeItem(ANSWER_STORAGE_KEY);
       }
+    } catch (error) {
+      console.warn("Failed to persist answers", error);
+    }
+  }, [encodedAnswers, hasAnswers]);
+
+  useEffect(() => {
+    const nextParams = new URLSearchParams();
+    if (hasAnswers) {
+      nextParams.set("answers", encodedAnswers);
+    }
+    if (isReview) {
+      nextParams.set("step", "review");
+    } else if (currentStep > 0) {
+      nextParams.set("step", String(currentStep));
+    }
+    const nextString = nextParams.toString();
+    if (nextString === searchParamsString) return;
+    const path = nextString.length ? `/questionnaire?${nextString}` : "/questionnaire";
+    router.replace(path, { scroll: false });
+  }, [encodedAnswers, hasAnswers, isReview, currentStep, router, searchParamsString]);
+
+  const currentQuestion = !isReview ? questions[currentStep] : null;
+  const isNoteStep = currentQuestion ? isNotePreferenceQuestion(currentQuestion) : false;
+  const selectedValues = currentQuestion ? sanitizedAnswers[currentQuestion.key] : [];
+  const selectedCount = selectedValues.length;
+
+  const goNext = useCallback(() => {
+    if (isReview) {
+      const query = new URLSearchParams({ answers: JSON.stringify(sanitizedAnswers) }).toString();
+      router.push(`/recommendations?${query}`);
       return;
     }
 
-    const currentParam = searchParams.get("answers");
-    if (currentParam === encodedAnswers) return;
-    const query = new URLSearchParams({ answers: encodedAnswers }).toString();
-    router.replace(`/questionnaire?${query}`, { scroll: false });
-  }, [encodedAnswers, hasAnswers, router, searchParams]);
-
-  const goNext = useCallback(() => {
     if (currentStep < totalSteps - 1) {
       setCurrentStep((step) => Math.min(step + 1, totalSteps - 1));
       return;
     }
 
-    const query = new URLSearchParams({ answers: JSON.stringify(sanitizeAnswers(answers)) }).toString();
-    router.push(`/recommendations?${query}`);
-  }, [answers, currentStep, router, totalSteps]);
+    setIsReview(true);
+  }, [currentStep, isReview, router, sanitizedAnswers, totalSteps]);
 
   const goBack = useCallback(() => {
+    if (isReview) {
+      setIsReview(false);
+      setCurrentStep(totalSteps - 1);
+      return;
+    }
     setCurrentStep((step) => Math.max(step - 1, 0));
-  }, []);
+  }, [isReview, totalSteps]);
+
+  const noteQuestionDefinition = useMemo(
+    () => questions.find((question) => isNotePreferenceQuestion(question)),
+    [questions]
+  );
+
+  const noteLikeLimit = noteQuestionDefinition?.maxSelections ?? Number.POSITIVE_INFINITY;
+  const noteDislikeLimit = noteQuestionDefinition?.maxDislikes ?? noteLikeLimit;
 
   const toggle = useCallback(
     (value: string) => {
+      if (!currentQuestion || isNotePreferenceQuestion(currentQuestion)) return;
       setAnswers((prev) => {
         const key = currentQuestion.key;
         const selected = prev[key];
@@ -111,8 +235,43 @@ const Questionnaire: React.FC = () => {
     [currentQuestion]
   );
 
+  const updateNotePreference = useCallback(
+    (value: string, preference: NotePreferenceValue) => {
+      setAnswers((prev) => {
+        const likes = new Set(prev.noteLikes);
+        const dislikes = new Set(prev.noteDislikes);
+        likes.delete(value);
+        dislikes.delete(value);
+        if (preference === "like") {
+          if (likes.size >= noteLikeLimit && !likes.has(value)) {
+            return prev;
+          }
+          likes.add(value);
+        } else if (preference === "dislike") {
+          if (dislikes.size >= noteDislikeLimit && !dislikes.has(value)) {
+            return prev;
+          }
+          dislikes.add(value);
+        }
+        return {
+          ...prev,
+          noteLikes: Array.from(likes),
+          noteDislikes: Array.from(dislikes),
+        };
+      });
+    },
+    [noteDislikeLimit, noteLikeLimit]
+  );
+
   const resetCurrent = useCallback(() => {
+    if (!currentQuestion) return;
     setAnswers((prev) => {
+      if (isNotePreferenceQuestion(currentQuestion)) {
+        if (prev.noteLikes.length === 0 && prev.noteDislikes.length === 0) {
+          return prev;
+        }
+        return { ...prev, noteLikes: [], noteDislikes: [] };
+      }
       const key = currentQuestion.key;
       if (prev[key].length === 0) return prev;
       return { ...prev, [key]: [] };
@@ -122,24 +281,35 @@ const Questionnaire: React.FC = () => {
   const resetAll = useCallback(() => {
     setAnswers(initialAnswers());
     setCurrentStep(0);
+    setIsReview(false);
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem(ANSWER_STORAGE_KEY);
+    }
     router.replace("/questionnaire", { scroll: false });
   }, [router]);
 
   useEffect(() => {
-    if (currentQuestion.type !== "single") return;
-    if (selectedValues.length === 0) return;
+    if (!settings.autoAdvanceSingle) return;
+    if (isReview) return;
+    const question = currentQuestion;
+    if (!question || question.type !== "single") return;
+    if (selectedCount === 0) return;
     const timer = window.setTimeout(() => {
       goNext();
     }, 420);
     return () => window.clearTimeout(timer);
-  }, [selectedValues, currentQuestion, goNext]);
+  }, [settings.autoAdvanceSingle, isReview, currentQuestion, selectedCount, goNext]);
 
-  const progressPercent = Math.round(((currentStep + 1) / totalSteps) * 100);
+  const progressPercent = isReview
+    ? 100
+    : Math.round(((currentStep + 1) / totalSteps) * 100);
   const progressPercentLabel = `${toPersianNumbers(String(progressPercent))}%`;
-  const progressLabel = `${TEXT.progressPrefix} ${toPersianNumbers(String(currentStep + 1))} ${TEXT.progressOf} ${toPersianNumbers(String(totalSteps))}`;
+  const progressLabel = isReview
+    ? TEXT.review.title
+    : `${TEXT.progressPrefix} ${toPersianNumbers(String(currentStep + 1))} ${TEXT.progressOf} ${toPersianNumbers(String(totalSteps))}`;
 
   const limitMessage = useMemo(() => {
-    if (currentQuestion.type !== "multiple" || typeof currentQuestion.maxSelections !== "number") {
+    if (!currentQuestion || currentQuestion.type !== "multiple" || typeof currentQuestion.maxSelections !== "number") {
       return null;
     }
     const max = currentQuestion.maxSelections;
@@ -154,63 +324,196 @@ const Questionnaire: React.FC = () => {
     return `${base} — می‌توانید ${toPersianNumbers(String(remaining))} گزینه دیگر برگزینید.`;
   }, [currentQuestion, selectedValues.length]);
 
-  const summaryChips = useMemo(() => {
-    const chips: string[] = [];
-    if (answers.moods.length) chips.push(`${TEXT.summaryLabels.moods}: ${separatorJoin(answers.moods)}`);
-    if (answers.moments.length) chips.push(`${TEXT.summaryLabels.moments}: ${separatorJoin(answers.moments)}`);
-    if (answers.times.length) chips.push(`${TEXT.summaryLabels.times}: ${separatorJoin(answers.times)}`);
-    if (answers.intensity.length) chips.push(`${TEXT.summaryLabels.intensity}: ${separatorJoin(answers.intensity)}`);
-    if (answers.styles.length) chips.push(`${TEXT.summaryLabels.styles}: ${separatorJoin(answers.styles)}`);
-    if (answers.noteLikes.length) chips.push(`${TEXT.summaryLabels.likes}: ${separatorJoin(answers.noteLikes)}`);
-    if (answers.noteDislikes.length) chips.push(`${TEXT.summaryLabels.dislikes}: ${separatorJoin(answers.noteDislikes)}`);
-    return chips.slice(0, SUMMARY_PREVIEW_LIMIT);
-  }, [answers]);
+  const stepIndexByKey = useMemo(() => {
+    const map = new Map<string, number>();
+    questions.forEach((question, index) => {
+      map.set(question.key, index);
+      if (isNotePreferenceQuestion(question)) {
+        map.set(question.pairedKey, index);
+      }
+    });
+    return map;
+  }, [questions]);
 
-  const canProceed = currentQuestion.optional || selectedValues.length > 0;
-  const helperText = currentQuestion.optional ? TEXT.optional : TEXT.requiredHint;
+  const summaryChips = useMemo(() => {
+    const chips: Array<{ text: string; stepIndex: number; active: boolean }> = [];
+    const maybePush = (text: string, key: keyof QuestionnaireAnswers) => {
+      const stepIndex = stepIndexByKey.get(key);
+      if (typeof stepIndex !== "number") return;
+      chips.push({
+        text,
+        stepIndex,
+        active: !isReview && stepIndex === currentStep,
+      });
+    };
+    if (sanitizedAnswers.moods.length) {
+      maybePush(`${TEXT.summaryLabels.moods}: ${separatorJoin(sanitizedAnswers.moods)}`, "moods");
+    }
+    if (sanitizedAnswers.moments.length) {
+      maybePush(`${TEXT.summaryLabels.moments}: ${separatorJoin(sanitizedAnswers.moments)}`, "moments");
+    }
+    if (sanitizedAnswers.times.length) {
+      maybePush(`${TEXT.summaryLabels.times}: ${separatorJoin(sanitizedAnswers.times)}`, "times");
+    }
+    if (sanitizedAnswers.intensity.length) {
+      maybePush(`${TEXT.summaryLabels.intensity}: ${separatorJoin(sanitizedAnswers.intensity)}`, "intensity");
+    }
+    if (sanitizedAnswers.styles.length) {
+      maybePush(`${TEXT.summaryLabels.styles}: ${separatorJoin(sanitizedAnswers.styles)}`, "styles");
+    }
+    if (sanitizedAnswers.noteLikes.length) {
+      maybePush(`${TEXT.summaryLabels.likes}: ${separatorJoin(sanitizedAnswers.noteLikes)}`, "noteLikes");
+    }
+    if (sanitizedAnswers.noteDislikes.length) {
+      maybePush(`${TEXT.summaryLabels.dislikes}: ${separatorJoin(sanitizedAnswers.noteDislikes)}`, "noteDislikes");
+    }
+    return chips.slice(0, SUMMARY_PREVIEW_LIMIT);
+  }, [currentStep, isReview, sanitizedAnswers, stepIndexByKey]);
+
+  const steps = useMemo(() => {
+    return questions.map((question, index) => {
+      const likes = sanitizedAnswers[question.key];
+      const dislikes = isNotePreferenceQuestion(question)
+        ? sanitizedAnswers[question.pairedKey]
+        : [];
+      const hasResponse = likes.length > 0 || dislikes.length > 0;
+      let status: "complete" | "current" | "upcoming" = "upcoming";
+      if (!isReview) {
+        if (index < currentStep) status = "complete";
+        else if (index === currentStep) status = "current";
+        else status = hasResponse ? "complete" : "upcoming";
+      } else {
+        status = hasResponse ? "complete" : "upcoming";
+      }
+      return {
+        title: question.title,
+        status,
+        optional: Boolean(question.optional),
+      };
+    });
+  }, [questions, sanitizedAnswers, isReview, currentStep]);
+
+  const noteHasSelection = sanitizedAnswers.noteLikes.length > 0 || sanitizedAnswers.noteDislikes.length > 0;
+  const canProceed = isReview
+    ? true
+    : currentQuestion
+      ? currentQuestion.optional || selectedValues.length > 0 || (isNoteStep && noteHasSelection)
+      : false;
+
+  const helperText = isReview
+    ? TEXT.review.helper
+    : currentQuestion
+      ? currentQuestion.optional
+        ? TEXT.optional
+        : TEXT.requiredHint
+      : undefined;
+
+  const autoAdvanceToggle = (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={settings.autoAdvanceSingle}
+      onClick={() => setSettings((prev) => ({ ...prev, autoAdvanceSingle: !prev.autoAdvanceSingle }))}
+      className={`flex items-center gap-2 rounded-full border px-3 py-1 text-xs transition-colors tap-highlight touch-target ${
+        settings.autoAdvanceSingle
+          ? "border-[var(--color-accent)] bg-[var(--accent-soft)] text-[var(--color-accent)]"
+          : "border-white/20 bg-white/10 text-muted"
+      }`}
+    >
+      <span
+        className={`inline-flex h-4 w-7 items-center rounded-full p-0.5 transition ${
+          settings.autoAdvanceSingle ? "justify-end bg-[var(--color-accent)]" : "justify-start bg-white/20"
+        }`}
+      >
+        <span className="h-3 w-3 rounded-full bg-white" />
+      </span>
+      {TEXT.settings.autoAdvance}
+    </button>
+  );
 
   return (
     <KioskFrame>
-      <div className="relative flex h-full w-full items-center justify-center">
+      <div className="relative flex h-full w-full items-center justify-center px-4 py-6">
         <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute left-16 top-12 h-48 w-48 rounded-full bg-amber-200/25 blur-[100px]" />
+          <div className="absolute left-10 top-12 h-48 w-48 rounded-full bg-amber-200/25 blur-[100px]" />
           <div className="absolute right-10 bottom-16 h-56 w-56 rounded-full bg-white/20 blur-[120px]" />
         </div>
-        <div className="relative flex h-full w-full max-w-[1200px] flex-col gap-6 rounded-3xl glass-deep px-6 py-8 shadow-2xl animate-blur-in">
+        <div className="relative grid h-full w-full max-w-[1300px] gap-6 rounded-3xl glass-deep px-4 py-6 shadow-2xl animate-blur-in lg:grid-cols-[360px,1fr] lg:px-10 lg:py-8">
           <ProgressPanel
-            title={currentQuestion.title}
-            description={currentQuestion.description}
+            title={isReview ? TEXT.review.title : currentQuestion?.title ?? TEXT.review.title}
+            description={isReview ? TEXT.review.description : currentQuestion?.description}
             progressLabel={progressLabel}
             progressPercent={progressPercent}
             progressPercentLabel={progressPercentLabel}
             summaryHeading={TEXT.summaryHeading}
             summaryChips={summaryChips}
-            optional={Boolean(currentQuestion.optional)}
+            optional={Boolean(!isReview && currentQuestion?.optional)}
             optionalLabel={TEXT.optional}
-            limitMessage={limitMessage}
-            onResetCurrent={resetCurrent}
+            limitMessage={isReview ? null : limitMessage}
+            onResetCurrent={isReview ? undefined : resetCurrent}
             onResetAll={resetAll}
+            onSelectStep={(stepIndex) => {
+              setIsReview(false);
+              setCurrentStep(stepIndex);
+            }}
+            steps={steps}
+            settingsSlot={autoAdvanceToggle}
           />
 
-          <section className="flex flex-1 items-center justify-center animate-scale-in animate-delay-2">
-            <OptionGrid
-              question={currentQuestion}
-              selectedValues={selectedValues}
-              onToggle={toggle}
-              emptyMessage={TEXT.noOptions}
-            />
-          </section>
+          <div className="relative flex h-full flex-col gap-4">
+            <section className="flex flex-1 flex-col gap-6 overflow-y-auto rounded-3xl border border-white/12 bg-white/8 p-5 animate-scale-in animate-delay-2">
+              {!isReview && currentQuestion && !isNotePreferenceQuestion(currentQuestion) && (
+                <OptionGrid
+                  question={currentQuestion}
+                  selectedValues={selectedValues}
+                  onToggle={toggle}
+                  emptyMessage={TEXT.noOptions}
+                />
+              )}
 
-          <NavigationControls
-            onBack={goBack}
-            onNext={goNext}
-            disableBack={currentStep === 0}
-            disableNext={!canProceed}
-            backLabel={TEXT.back}
-            nextLabel={currentStep === totalSteps - 1 ? TEXT.finish : TEXT.next}
-            helperText={helperText}
-            isOptional={Boolean(currentQuestion.optional)}
-          />
+              {!isReview && currentQuestion && isNotePreferenceQuestion(currentQuestion) && (
+                <NotePreferenceGrid
+                  options={currentQuestion.options}
+                  likes={sanitizedAnswers.noteLikes}
+                  dislikes={sanitizedAnswers.noteDislikes}
+                  maxLikes={currentQuestion.maxSelections}
+                  maxDislikes={currentQuestion.maxDislikes}
+                  likeLabel={TEXT.notePreferences.like}
+                  dislikeLabel={TEXT.notePreferences.dislike}
+                  neutralLabel={TEXT.notePreferences.neutral}
+                  neutralDescription={TEXT.notePreferences.neutralDescription}
+                  onChange={updateNotePreference}
+                />
+              )}
+
+              {isReview && (
+                <ReviewStep
+                  answers={sanitizedAnswers}
+                  questions={questions}
+                  summaryLabels={TEXT.summaryLabels}
+                  emptyLabel={TEXT.review.empty}
+                  formatValues={separatorJoin}
+                  onEditStep={(index) => {
+                    setIsReview(false);
+                    setCurrentStep(index);
+                  }}
+                />
+              )}
+            </section>
+
+            <div className="lg:sticky lg:bottom-0">
+              <NavigationControls
+                onBack={goBack}
+                onNext={goNext}
+                disableBack={isReview ? false : currentStep === 0}
+                disableNext={!canProceed}
+                backLabel={TEXT.back}
+                nextLabel={isReview ? TEXT.review.confirm : currentStep === totalSteps - 1 ? TEXT.finish : TEXT.next}
+                helperText={helperText ?? undefined}
+                isOptional={Boolean(!isReview && currentQuestion?.optional)}
+              />
+            </div>
+          </div>
         </div>
       </div>
     </KioskFrame>

--- a/src/app/recommendations/page.tsx
+++ b/src/app/recommendations/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { Suspense, useEffect, useMemo, useState } from "react";
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -17,6 +17,7 @@ import {
   type QuestionnaireAnswers,
   sanitizeAnswers,
   separatorJoin,
+  QUESTION_CONFIG,
 } from "@/lib/questionnaire";
 import {
   describeMatchQuality,
@@ -35,6 +36,11 @@ const TEXT = {
   refine: "ویرایش پاسخ‌ها",
   restart: "شروع دوباره",
   coverage: "پوشش ترجیحات",
+  error: {
+    heading: "خطا در دریافت پیشنهادها",
+    description: "مشکلی در ارتباط با سرور رخ داد. لطفاً دوباره تلاش کنید.",
+    retry: "تلاش مجدد",
+  },
   intensity: {
     light: "ملایم",
     medium: "متعادل",
@@ -55,9 +61,13 @@ const TEXT = {
   },
 };
 
+const STEP_KEYS = QUESTION_CONFIG.map((question) => question.key);
+
 type IntensityKey = keyof typeof TEXT.intensity;
 
 type ReasonCode = keyof typeof TEXT.reasons | keyof typeof TEXT.warnings;
+
+type SummaryChip = { text: string; key: string };
 
 const formatReason = (reason: MatchReason): DisplayReason | null => {
   const valueLabel = reason.value ? LABEL_LOOKUP[reason.value] ?? reason.value : undefined;
@@ -86,16 +96,17 @@ const formatReason = (reason: MatchReason): DisplayReason | null => {
   }
 };
 
-const buildSummary = (answers: QuestionnaireAnswers | null) => {
-  if (!answers) return [] as string[];
-  const chips: string[] = [];
-  if (answers.moods.length) chips.push(`${QUESTION_TEXT.summaryLabels.moods}: ${separatorJoin(answers.moods)}`);
-  if (answers.moments.length) chips.push(`${QUESTION_TEXT.summaryLabels.moments}: ${separatorJoin(answers.moments)}`);
-  if (answers.times.length) chips.push(`${QUESTION_TEXT.summaryLabels.times}: ${separatorJoin(answers.times)}`);
-  if (answers.intensity.length) chips.push(`${QUESTION_TEXT.summaryLabels.intensity}: ${separatorJoin(answers.intensity)}`);
-  if (answers.styles.length) chips.push(`${QUESTION_TEXT.summaryLabels.styles}: ${separatorJoin(answers.styles)}`);
-  if (answers.noteLikes.length) chips.push(`${QUESTION_TEXT.summaryLabels.likes}: ${separatorJoin(answers.noteLikes)}`);
-  if (answers.noteDislikes.length) chips.push(`${QUESTION_TEXT.summaryLabels.dislikes}: ${separatorJoin(answers.noteDislikes)}`);
+const buildSummary = (answers: QuestionnaireAnswers | null): SummaryChip[] => {
+  if (!answers) return [];
+  const chips: SummaryChip[] = [];
+  const push = (key: string, text: string) => chips.push({ key, text });
+  if (answers.moods.length) push("moods", `${QUESTION_TEXT.summaryLabels.moods}: ${separatorJoin(answers.moods)}`);
+  if (answers.moments.length) push("moments", `${QUESTION_TEXT.summaryLabels.moments}: ${separatorJoin(answers.moments)}`);
+  if (answers.times.length) push("times", `${QUESTION_TEXT.summaryLabels.times}: ${separatorJoin(answers.times)}`);
+  if (answers.intensity.length) push("intensity", `${QUESTION_TEXT.summaryLabels.intensity}: ${separatorJoin(answers.intensity)}`);
+  if (answers.styles.length) push("styles", `${QUESTION_TEXT.summaryLabels.styles}: ${separatorJoin(answers.styles)}`);
+  if (answers.noteLikes.length) push("noteLikes", `${QUESTION_TEXT.summaryLabels.likes}: ${separatorJoin(answers.noteLikes)}`);
+  if (answers.noteDislikes.length) push("noteDislikes", `${QUESTION_TEXT.summaryLabels.dislikes}: ${separatorJoin(answers.noteDislikes)}`);
   return chips.slice(0, SUMMARY_PREVIEW_LIMIT);
 };
 
@@ -105,6 +116,8 @@ const RecommendationsContent: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [answers, setAnswers] = useState<QuestionnaireAnswers | null>(null);
   const [compact, setCompact] = useState<CompactMode>("normal");
+  const [error, setError] = useState<string | null>(null);
+  const [retryToken, setRetryToken] = useState(0);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -119,30 +132,36 @@ const RecommendationsContent: React.FC = () => {
     return () => window.removeEventListener("resize", evaluate);
   }, []);
 
-  useEffect(() => {
-    async function generate() {
-      try {
-        const answersParam = searchParams.get("answers");
-        if (!answersParam) {
-          setLoading(false);
-          return;
-        }
-
-        const parsed = JSON.parse(answersParam) as Partial<QuestionnaireAnswers>;
-        const sanitized = sanitizeAnswers(parsed);
-        setAnswers(sanitized);
-
-        const allPerfumes = await getPerfumes();
-        const ranked = rankPerfumes(allPerfumes, sanitized, 6);
-        setRecommendations(ranked);
-      } catch (error) {
-        console.error("Error generating recommendations:", error);
-      } finally {
-        setLoading(false);
+  const fetchRecommendations = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const answersParam = searchParams.get("answers");
+      if (!answersParam) {
+        setAnswers(null);
+        setRecommendations([]);
+        return;
       }
+
+      const parsed = JSON.parse(answersParam) as Partial<QuestionnaireAnswers>;
+      const sanitized = sanitizeAnswers(parsed);
+      setAnswers(sanitized);
+
+      const allPerfumes = await getPerfumes();
+      const ranked = rankPerfumes(allPerfumes, sanitized, 6);
+      setRecommendations(ranked);
+    } catch (err) {
+      console.error("Error generating recommendations:", err);
+      setError(TEXT.error.description);
+      setRecommendations([]);
+    } finally {
+      setLoading(false);
     }
-    generate();
   }, [searchParams]);
+
+  useEffect(() => {
+    fetchRecommendations();
+  }, [fetchRecommendations, retryToken]);
 
   const summaryChips = useMemo(() => buildSummary(answers), [answers]);
 
@@ -150,6 +169,17 @@ const RecommendationsContent: React.FC = () => {
     if (!answers) return null;
     return new URLSearchParams({ answers: JSON.stringify(answers) }).toString();
   }, [answers]);
+
+  const refineHref = useMemo(() => {
+    if (!answersQuery) return "/questionnaire";
+    const params = new URLSearchParams(answersQuery);
+    params.set("step", "review");
+    return `/questionnaire?${params.toString()}`;
+  }, [answersQuery]);
+
+  const handleRetry = useCallback(() => {
+    setRetryToken((token) => token + 1);
+  }, []);
 
   if (loading) {
     return (
@@ -181,28 +211,35 @@ const RecommendationsContent: React.FC = () => {
         <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between animate-slide-in-right">
           <div className="space-y-1 text-right">
             <h1 className="text-3xl font-semibold text-[var(--color-foreground)]">{TEXT.heading}</h1>
-            {summaryChips.length > 0 && (
+            {summaryChips.length > 0 && answersQuery && (
               <div className="flex flex-wrap justify-end gap-2 text-xs text-muted">
                 <span className="rounded-full border border-white/25 px-3 py-1 font-semibold text-[var(--color-accent)]">
                   {TEXT.summaryHeading}
                 </span>
-                {summaryChips.map((chip, index) => (
-                  <span key={index} className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs">
-                    {chip}
-                  </span>
-                ))}
+                {summaryChips.map((chip, index) => {
+                  const params = new URLSearchParams(answersQuery);
+                  if (STEP_KEYS.includes(chip.key)) {
+                    params.set("step", chip.key);
+                  } else {
+                    params.set("step", "review");
+                  }
+                  return (
+                    <Link
+                      key={`${chip.key}-${index}`}
+                      href={`/questionnaire?${params.toString()}`}
+                      className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs transition-colors hover:border-white/35 tap-highlight touch-target"
+                    >
+                      {chip.text}
+                    </Link>
+                  );
+                })}
               </div>
             )}
           </div>
           <div className="flex items-center justify-end gap-3">
-            {answersQuery && (
-              <Link
-                href={`/questionnaire?${answersQuery}`}
-                className="btn-ghost tap-highlight touch-target touch-feedback"
-              >
-                {TEXT.refine}
-              </Link>
-            )}
+            <Link href={refineHref} className="btn-ghost tap-highlight touch-target touch-feedback">
+              {TEXT.refine}
+            </Link>
             <Link href="/questionnaire" className="btn tap-highlight touch-target touch-feedback">
               {TEXT.restart}
             </Link>
@@ -210,7 +247,19 @@ const RecommendationsContent: React.FC = () => {
         </header>
 
         <section className="grid flex-1 auto-rows-fr gap-3 sm:grid-cols-2 xl:grid-cols-3 animate-scale-in animate-delay-2">
-          {recommendations.length > 0 ? (
+          {error ? (
+            <div className="glass-surface col-span-full flex h-full flex-col items-center justify-center gap-3 rounded-3xl px-6 text-center text-sm text-muted animate-fade-in-up animate-delay-3">
+              <p className="m-0 text-base font-semibold text-[var(--color-foreground)]">{TEXT.error.heading}</p>
+              <p className="m-0 text-sm text-muted">{error}</p>
+              <button
+                type="button"
+                onClick={handleRetry}
+                className="btn tap-highlight touch-target touch-feedback"
+              >
+                {TEXT.error.retry}
+              </button>
+            </div>
+          ) : recommendations.length > 0 ? (
             recommendations.map((perfume, index) => {
               const matchPercentLabel = `${toPersianNumbers(String(perfume.matchPercentage))}%`;
               const matchQuality = describeMatchQuality(perfume.matchPercentage);

--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
-import { useEffect, useRef } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 
 interface GradientCircle {
   id: number;
@@ -11,11 +10,7 @@ interface GradientCircle {
   color: string;
 }
 
-export default function AnimatedBackground() {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const isAnimatingRef = useRef(false);
-
-  const circles: GradientCircle[] = [
+const circles: GradientCircle[] = [
     {
       id: 1,
       x: 20,
@@ -39,21 +34,17 @@ export default function AnimatedBackground() {
     },
   ];
 
-  useEffect(() => {
-    const handleButtonClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'BUTTON' || target.tagName === 'A' || target.closest('button') || target.closest('a')) {
-        // Simple animation trigger - let Framer Motion handle the animation
-        isAnimatingRef.current = true;
-        setTimeout(() => {
-          isAnimatingRef.current = false;
-        }, 2500);
-      }
-    };
+export default function AnimatedBackground() {
+  const prefersReducedMotion = useReducedMotion();
 
-    document.addEventListener('click', handleButtonClick);
-    return () => document.removeEventListener('click', handleButtonClick);
-  }, []);
+  if (prefersReducedMotion) {
+    return (
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50"
+      />
+    );
+  }
 
   const getAnimationProps = (index: number) => {
     const circle = circles[index];
@@ -87,7 +78,7 @@ export default function AnimatedBackground() {
   };
 
   return (
-    <div ref={containerRef}>
+    <div aria-hidden>
       <div className="absolute inset-0 bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50"></div>
       {circles.map((circle, index) => (
         <motion.div

--- a/src/components/questionnaire/NavigationControls.tsx
+++ b/src/components/questionnaire/NavigationControls.tsx
@@ -3,49 +3,61 @@
 import React from "react";
 
 interface NavigationControlsProps {
-  onBack: () => void;
-  onNext: () => void;
-  disableBack: boolean;
-  disableNext: boolean;
-  backLabel: string;
-  nextLabel: string;
-  helperText: string;
-  isOptional: boolean;
+  onBack?: () => void;
+  onNext?: () => void;
+  disableBack?: boolean;
+  disableNext?: boolean;
+  backLabel?: string;
+  nextLabel?: string;
+  helperText?: string | null;
+  isOptional?: boolean;
+  showBack?: boolean;
+  showNext?: boolean;
 }
 
 const NavigationControls: React.FC<NavigationControlsProps> = ({
   onBack,
   onNext,
-  disableBack,
-  disableNext,
-  backLabel,
-  nextLabel,
+  disableBack = false,
+  disableNext = false,
+  backLabel = "بازگشت",
+  nextLabel = "ادامه",
   helperText,
-  isOptional,
+  isOptional = false,
+  showBack = true,
+  showNext = true,
 }) => {
   return (
-    <footer className="flex items-center justify-between gap-3 animate-slide-in-left animate-delay-3">
-      <button
-        onClick={onBack}
-        disabled={disableBack}
-        className="btn-ghost w-32 tap-highlight touch-target touch-feedback"
-      >
-        {backLabel}
-      </button>
-      <span className="text-xs text-muted" aria-live="polite">
-        {isOptional ? (
-          <span className="text-[var(--color-accent)]">{helperText}</span>
-        ) : (
-          helperText
+    <footer className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 shadow-lg backdrop-blur-md animate-slide-in-left animate-delay-3 lg:flex-row lg:items-center lg:justify-between">
+      {helperText && (
+        <span className="text-xs text-muted" aria-live="polite">
+          {isOptional ? (
+            <span className="text-[var(--color-accent)]">{helperText}</span>
+          ) : (
+            helperText
+          )}
+        </span>
+      )}
+      <div className="flex w-full items-center justify-between gap-3 lg:w-auto lg:justify-end">
+        {showBack && (
+          <button
+            onClick={onBack}
+            disabled={disableBack}
+            className="btn-ghost w-full lg:w-32 tap-highlight touch-target touch-feedback"
+          >
+            {backLabel}
+          </button>
         )}
-      </span>
-      <button
-        onClick={onNext}
-        disabled={disableNext}
-        className="btn w-36 tap-highlight touch-target touch-feedback"
-      >
-        {nextLabel}
-      </button>
+        {showNext && (
+          <button
+            onClick={onNext}
+            disabled={disableNext}
+            className="btn w-full lg:w-36 tap-highlight touch-target touch-feedback"
+          >
+            {nextLabel}
+          </button>
+        )}
+      </div>
     </footer>
   );
 };

--- a/src/components/questionnaire/NotePreferenceGrid.tsx
+++ b/src/components/questionnaire/NotePreferenceGrid.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React from "react";
+
+import type { Choice } from "@/lib/kiosk-options";
+
+export type NotePreferenceValue = "like" | "dislike" | "neutral";
+
+interface NotePreferenceGridProps {
+  options: Choice[];
+  likes: string[];
+  dislikes: string[];
+  maxLikes?: number;
+  maxDislikes?: number;
+  likeLabel: string;
+  dislikeLabel: string;
+  neutralLabel: string;
+  neutralDescription: string;
+  onChange: (value: string, preference: NotePreferenceValue) => void;
+}
+
+const STATUS_CLASS: Record<NotePreferenceValue, string> = {
+  like: "bg-[var(--accent-soft)] border-[var(--color-accent)] text-[var(--color-accent)]",
+  dislike: "bg-rose-100/10 border-rose-200/40 text-rose-100",
+  neutral: "bg-white/6 border-white/15 text-[var(--color-foreground)]",
+};
+
+const BUTTON_BASE =
+  "flex flex-1 items-center justify-center gap-1 rounded-full border px-3 py-2 text-xs font-semibold transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent tap-highlight touch-target";
+
+const NotePreferenceGrid: React.FC<NotePreferenceGridProps> = ({
+  options,
+  likes,
+  dislikes,
+  maxLikes,
+  maxDislikes,
+  likeLabel,
+  dislikeLabel,
+  neutralLabel,
+  neutralDescription,
+  onChange,
+}) => {
+  const likeLimit = typeof maxLikes === "number" ? Math.max(maxLikes, 0) : Number.POSITIVE_INFINITY;
+  const dislikeLimit =
+    typeof maxDislikes === "number" ? Math.max(maxDislikes, 0) : Number.POSITIVE_INFINITY;
+
+  const reachedLikeLimit = likes.length >= likeLimit;
+  const reachedDislikeLimit = dislikes.length >= dislikeLimit;
+
+  const resolveStatus = (value: string): NotePreferenceValue => {
+    if (likes.includes(value)) return "like";
+    if (dislikes.includes(value)) return "dislike";
+    return "neutral";
+  };
+
+  const handleToggle = (value: string, next: NotePreferenceValue) => {
+    const current = resolveStatus(value);
+    if (current === next) {
+      onChange(value, "neutral");
+      return;
+    }
+    if (next === "like" && reachedLikeLimit && !likes.includes(value)) {
+      return;
+    }
+    if (next === "dislike" && reachedDislikeLimit && !dislikes.includes(value)) {
+      return;
+    }
+    onChange(value, next);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      {options.map((option) => {
+        const status = resolveStatus(option.value);
+        const likeDisabled = reachedLikeLimit && status !== "like";
+        const dislikeDisabled = reachedDislikeLimit && status !== "dislike";
+        const neutralDisabled = status === "neutral";
+
+        return (
+          <div
+            key={option.value}
+            className="flex flex-col gap-3 rounded-3xl border border-white/12 bg-white/6 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+          >
+            <div className="flex items-center justify-between gap-3 sm:justify-start">
+              {option.icon && (
+                <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/12 text-xl">
+                  {option.icon}
+                </span>
+              )}
+              <div className="text-right">
+                <span className="block text-sm font-semibold text-[var(--color-foreground)]">
+                  {option.label}
+                </span>
+                <span className="text-[11px] text-muted">{neutralDescription}</span>
+              </div>
+            </div>
+
+            <div className="flex w-full gap-2 sm:w-auto">
+              <button
+                type="button"
+                onClick={() => handleToggle(option.value, "like")}
+                disabled={likeDisabled}
+                aria-pressed={status === "like"}
+                className={`${BUTTON_BASE} ${STATUS_CLASS[status === "like" ? "like" : "neutral"]} ${
+                  likeDisabled && status !== "like" ? "opacity-50" : ""
+                }`}
+              >
+                <span role="img" aria-hidden>
+                  💛
+                </span>
+                {likeLabel}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleToggle(option.value, "dislike")}
+                disabled={dislikeDisabled}
+                aria-pressed={status === "dislike"}
+                className={`${BUTTON_BASE} ${STATUS_CLASS[status === "dislike" ? "dislike" : "neutral"]} ${
+                  dislikeDisabled && status !== "dislike" ? "opacity-50" : ""
+                }`}
+              >
+                <span role="img" aria-hidden>
+                  🚫
+                </span>
+                {dislikeLabel}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleToggle(option.value, "neutral")}
+                disabled={neutralDisabled}
+                aria-pressed={status === "neutral"}
+                className={`${BUTTON_BASE} ${STATUS_CLASS[status === "neutral" ? "neutral" : "neutral"]} ${
+                  neutralDisabled ? "opacity-50" : ""
+                }`}
+              >
+                {neutralLabel}
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default NotePreferenceGrid;

--- a/src/components/questionnaire/ProgressPanel.tsx
+++ b/src/components/questionnaire/ProgressPanel.tsx
@@ -2,6 +2,18 @@
 
 import React from "react";
 
+interface SummaryChip {
+  text: string;
+  stepIndex: number;
+  active: boolean;
+}
+
+interface StepIndicator {
+  title: string;
+  status: "complete" | "current" | "upcoming";
+  optional: boolean;
+}
+
 interface ProgressPanelProps {
   title: string;
   description?: string;
@@ -9,12 +21,15 @@ interface ProgressPanelProps {
   progressPercent: number;
   progressPercentLabel: string;
   summaryHeading: string;
-  summaryChips: string[];
+  summaryChips: SummaryChip[];
   optional: boolean;
   optionalLabel: string;
   limitMessage?: string | null;
   onResetCurrent?: () => void;
   onResetAll?: () => void;
+  onSelectStep?: (stepIndex: number) => void;
+  steps: StepIndicator[];
+  settingsSlot?: React.ReactNode;
 }
 
 const ProgressPanel: React.FC<ProgressPanelProps> = ({
@@ -30,82 +45,122 @@ const ProgressPanel: React.FC<ProgressPanelProps> = ({
   onResetCurrent,
   onResetAll,
   progressPercentLabel,
+  onSelectStep,
+  steps,
+  settingsSlot,
 }) => {
-  const hasActions = Boolean(onResetCurrent || onResetAll);
+  const hasActions = Boolean(onResetCurrent || onResetAll || settingsSlot);
 
   return (
-    <header className="flex flex-col gap-5 animate-slide-in-right">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="space-y-2 text-right">
-          <div className="flex items-center justify-between gap-2 text-xs font-medium text-muted" aria-live="polite">
-            <span>{progressLabel}</span>
-            {optional && (
-              <span className="rounded-full border border-white/30 px-2 py-0.5 text-[11px] text-[var(--color-accent)]">
-                {optionalLabel}
-              </span>
-            )}
-          </div>
-          <h1 className="text-3xl font-semibold text-[var(--color-foreground)]">{title}</h1>
-          {description && <p className="m-0 text-sm text-muted">{description}</p>}
-          {limitMessage && (
-            <p className="m-0 text-xs text-[var(--color-accent)]" role="status">
-              {limitMessage}
-            </p>
+    <aside className="flex h-full flex-col gap-6 animate-slide-in-right">
+      <div className="space-y-3 text-right">
+        <div className="flex items-center justify-between gap-2 text-xs font-medium text-muted" aria-live="polite">
+          <span>{progressLabel}</span>
+          {optional && (
+            <span className="rounded-full border border-white/30 px-2 py-0.5 text-[11px] text-[var(--color-accent)]">
+              {optionalLabel}
+            </span>
           )}
         </div>
+        <h1 className="text-3xl font-semibold text-[var(--color-foreground)]">{title}</h1>
+        {description && <p className="m-0 text-sm text-muted">{description}</p>}
+        {limitMessage && (
+          <p className="m-0 text-xs text-[var(--color-accent)]" role="status">
+            {limitMessage}
+          </p>
+        )}
+      </div>
 
-        <div className="flex w-full flex-col items-end gap-2 sm:w-56">
-          <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-white/15">
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="relative h-2.5 flex-1 overflow-hidden rounded-full bg-white/15">
             <div
               className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-amber-200 via-amber-300 to-orange-300 shadow-lg transition-[width] duration-500"
               style={{ width: `${progressPercent}%` }}
             />
           </div>
-          <span className="text-xs font-semibold text-[var(--color-accent)]">
-            {progressPercentLabel}
-          </span>
-          {hasActions && (
-            <div className="flex items-center gap-2 text-xs text-muted">
-              {onResetCurrent && (
-                <button
-                  type="button"
-                  onClick={onResetCurrent}
-                  className="btn-ghost px-3 py-1 text-xs tap-highlight touch-target"
-                >
-                  پاک کردن این سوال
-                </button>
-              )}
-              {onResetAll && (
-                <button
-                  type="button"
-                  onClick={onResetAll}
-                  className="btn-ghost px-3 py-1 text-xs tap-highlight touch-target"
-                >
-                  شروع دوباره
-                </button>
-              )}
-            </div>
-          )}
+          <span className="text-xs font-semibold text-[var(--color-accent)]">{progressPercentLabel}</span>
         </div>
+        {hasActions && (
+          <div className="flex flex-wrap items-center justify-end gap-2 text-xs text-muted">
+            {settingsSlot}
+            {onResetCurrent && (
+              <button
+                type="button"
+                onClick={onResetCurrent}
+                className="btn-ghost px-3 py-1 text-xs tap-highlight touch-target"
+              >
+                پاک کردن این سوال
+              </button>
+            )}
+            {onResetAll && (
+              <button
+                type="button"
+                onClick={onResetAll}
+                className="btn-ghost px-3 py-1 text-xs tap-highlight touch-target"
+              >
+                شروع دوباره
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {summaryChips.length > 0 && (
-        <div
-          className="flex flex-wrap justify-end gap-2 text-xs text-muted"
-          aria-live="polite"
-          aria-label={summaryHeading}
-        >
-          <span className="rounded-full border border-white/25 px-3 py-1 font-semibold text-[var(--color-accent)]">
+        <div className="space-y-2" aria-live="polite" aria-label={summaryHeading}>
+          <span className="rounded-full border border-white/25 px-3 py-1 text-xs font-semibold text-[var(--color-accent)]">
             {summaryHeading}
           </span>
-          {summaryChips.map((chip, index) => (
-            <span key={index} className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs">
-              {chip}
-            </span>
-          ))}
+          <div className="flex flex-wrap justify-end gap-2 text-xs text-muted">
+            {summaryChips.map((chip) => (
+              <button
+                key={`${chip.stepIndex}-${chip.text}`}
+                type="button"
+                onClick={() => onSelectStep?.(chip.stepIndex)}
+                className={`rounded-full border px-3 py-1 transition-colors tap-highlight touch-target ${
+                  chip.active
+                    ? "border-[var(--color-accent)] bg-[var(--accent-soft)] text-[var(--color-accent)]"
+                    : "border-white/20 bg-white/10 text-muted hover:border-white/30"
+                }`}
+                aria-current={chip.active ? "step" : undefined}
+              >
+                {chip.text}
+              </button>
+            ))}
+          </div>
         </div>
       )}
-    </header>
+
+      <ol className="flex flex-1 flex-col gap-2 overflow-y-auto pr-1" aria-label="پیشرفت پرسشنامه">
+        {steps.map((step, index) => {
+          const statusBadge =
+            step.status === "current"
+              ? "bg-[var(--accent-soft)] text-[var(--color-accent)] border-[var(--color-accent)]"
+              : step.status === "complete"
+                ? "bg-emerald-100/15 text-emerald-200 border-emerald-200/40"
+                : "bg-white/6 text-muted border-white/15";
+
+          return (
+            <li
+              key={`${step.title}-${index}`}
+              className={`rounded-2xl border px-3 py-2 text-xs leading-5 transition-colors ${statusBadge}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-semibold text-[var(--color-foreground)]">{step.title}</span>
+                {step.optional && <span className="text-[10px] text-muted">{optionalLabel}</span>}
+              </div>
+              <span className="text-[11px] text-muted">
+                {step.status === "current"
+                  ? "در حال پاسخ دادن"
+                  : step.status === "complete"
+                    ? "پاسخ تکمیل شد"
+                    : "منتظر پاسخ"}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </aside>
   );
 };
 

--- a/src/components/questionnaire/ReviewStep.tsx
+++ b/src/components/questionnaire/ReviewStep.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React from "react";
+
+import {
+  type QuestionnaireAnswers,
+  type QuestionDefinition,
+  isNotePreferenceQuestion,
+} from "@/lib/questionnaire";
+
+interface ReviewStepProps {
+  answers: QuestionnaireAnswers;
+  questions: QuestionDefinition[];
+  summaryLabels: Record<string, string>;
+  emptyLabel: string;
+  formatValues: (values: string[]) => string;
+  onEditStep: (stepIndex: number) => void;
+}
+
+const ReviewStep: React.FC<ReviewStepProps> = ({
+  answers,
+  questions,
+  summaryLabels,
+  emptyLabel,
+  formatValues,
+  onEditStep,
+}) => {
+  return (
+    <div className="flex h-full w-full flex-col gap-4 overflow-y-auto pr-1">
+      {questions.map((question, index) => {
+        const values = answers[question.key];
+        const isNoteQuestion = isNotePreferenceQuestion(question);
+        const pairedValues = isNoteQuestion ? answers[question.pairedKey] : [];
+        const hasValue = values.length > 0 || pairedValues.length > 0;
+
+        const summaryParts: string[] = [];
+        if (values.length > 0) {
+          summaryParts.push(`${summaryLabels.likes}: ${formatValues(values)}`);
+        }
+        if (pairedValues.length > 0) {
+          summaryParts.push(`${summaryLabels.dislikes}: ${formatValues(pairedValues)}`);
+        }
+
+        const summaryText = !hasValue
+          ? emptyLabel
+          : isNoteQuestion
+            ? summaryParts.join(" • ")
+            : formatValues(values);
+
+        return (
+          <article
+            key={question.key}
+            className="flex flex-col gap-3 rounded-3xl border border-white/12 bg-white/8 p-4 text-right shadow-sm"
+          >
+            <header className="flex items-center justify-between gap-3">
+              <div className="flex flex-col">
+                <span className="text-sm font-semibold text-[var(--color-foreground)]">
+                  {question.title}
+                </span>
+                {question.description && (
+                  <span className="text-[11px] text-muted">{question.description}</span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => onEditStep(index)}
+                className="btn-ghost shrink-0 rounded-full px-3 py-1 text-xs tap-highlight touch-target touch-feedback"
+              >
+                ویرایش
+              </button>
+            </header>
+            <p className="m-0 rounded-2xl bg-white/6 px-3 py-2 text-xs text-[var(--color-foreground)]">
+              {summaryText}
+            </p>
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ReviewStep;

--- a/src/components/recommendations/MatchCard.tsx
+++ b/src/components/recommendations/MatchCard.tsx
@@ -82,6 +82,7 @@ const MatchCard: React.FC<MatchCardProps> = ({
   const visibleReasons = reasons.slice(0, reasonLimit);
   const notePreview = perfume.allNotes.slice(0, compact === "ultra" ? 2 : 4);
 
+  const [expanded, setExpanded] = React.useState(false);
   const articleRef = React.useRef<HTMLDivElement>(null);
   const emitRipple = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     const node = articleRef.current;
@@ -91,14 +92,31 @@ const MatchCard: React.FC<MatchCardProps> = ({
     ripple?.(event.clientX - rect.left, event.clientY - rect.top);
   }, []);
 
+  const toggleExpanded = React.useCallback(() => {
+    setExpanded((prev) => !prev);
+  }, []);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        toggleExpanded();
+      }
+    },
+    [toggleExpanded]
+  );
+
   return (
     <article
       ref={articleRef}
       role="button"
       tabIndex={0}
       onPointerDown={emitRipple}
+      onClick={toggleExpanded}
+      onKeyDown={handleKeyDown}
+      aria-expanded={expanded}
       aria-label={`${title ?? ""} - درصد تطابق ${matchPercentLabel}`}
-      className="interactive-card glass-card relative flex h-full flex-col justify-between rounded-2xl p-4 text-right animate-fade-in-up tap-highlight touch-target"
+      className="interactive-card glass-card relative flex h-full flex-col justify-between rounded-2xl p-4 text-right animate-fade-in-up tap-highlight touch-target focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
     >
       <TouchRipple />
       <header className="flex items-start justify-between">
@@ -177,6 +195,19 @@ const MatchCard: React.FC<MatchCardProps> = ({
               {note}
             </span>
           ))}
+        </div>
+      )}
+
+      {expanded && perfume.allNotes.length > 0 && (
+        <div className="mt-3 rounded-2xl border border-white/12 bg-white/8 p-3 text-[11px] text-muted">
+          <p className="m-0 text-[11px] text-[var(--color-foreground)]">نُت‌های کامل:</p>
+          <div className="mt-2 flex flex-wrap justify-end gap-2">
+            {perfume.allNotes.map((note, index) => (
+              <span key={index} className="rounded-full bg-white/10 px-2 py-1">
+                {note}
+              </span>
+            ))}
+          </div>
         </div>
       )}
     </article>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,10 @@
-﻿const API_URL = "http://192.168.1.19:1337";
+const DEFAULT_STRAPI_URL = "http://localhost:1337";
+const normaliseBaseUrl = (value: string) => value.replace(/\/$/, "");
+const API_URL = normaliseBaseUrl(
+  process.env.NEXT_PUBLIC_STRAPI_BASE_URL && process.env.NEXT_PUBLIC_STRAPI_BASE_URL.trim().length > 0
+    ? process.env.NEXT_PUBLIC_STRAPI_BASE_URL.trim()
+    : DEFAULT_STRAPI_URL
+);
 const STRAPI_TOKEN = process.env.NEXT_PUBLIC_STRAPI_TOKEN;
 
 type PerfumeAttributeKey = "family" | "season" | "character" | "gender";


### PR DESCRIPTION
## Summary
- redesign the questionnaire with a responsive two-column layout, review step, note preference controls, interactive summary chips, and session-backed persistence with an optional auto-advance toggle
- improve the recommendations screen by handling API failures, turning summary chips into deep links back to targeted questions, and adding expandable match cards for richer interaction
- refresh shared surfaces with updated landing page onboarding, reduced-motion-friendly backgrounds, restored text selection outside kiosk mode, and environment-driven Strapi configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c171bbd483208aac30a986320dbd