### PR TITLE
Refine motion system for kiosk experience

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -302,9 +302,12 @@
     position: relative;
     overflow: hidden;
     transition:
-      transform 160ms ease,
-      box-shadow 220ms ease,
-      filter 160ms ease;
+      transform 280ms cubic-bezier(0.16, 1, 0.3, 1),
+      box-shadow 340ms cubic-bezier(0.16, 1, 0.3, 1),
+      filter 200ms ease,
+      opacity 200ms ease;
+    transform: translateY(0);
+    will-change: transform, box-shadow;
   }
 
   button::before,
@@ -324,8 +327,8 @@
 
   button:hover,
   .btn:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 22px 46px rgba(var(--shadow-color) / 0.18);
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: 0 24px 52px rgba(var(--shadow-color) / 0.18);
     filter: brightness(1.01);
   }
 
@@ -338,9 +341,9 @@
   
   button:active,
   .btn:active {
-    transform: scale(0.98);
-    box-shadow: 0 12px 26px rgba(var(--shadow-color) / 0.18);
-    filter: brightness(0.98);
+    transform: translateY(0) scale(0.985);
+    box-shadow: 0 12px 28px rgba(var(--shadow-color) / 0.18);
+    filter: brightness(0.985);
   }
 
   button:focus-visible,
@@ -547,12 +550,15 @@
     backdrop-filter: blur(12px);
     box-shadow: 0 12px 28px rgba(var(--shadow-color) / 0.07);
     transition:
-      border-color 200ms ease,
-      background 220ms ease,
-      color 180ms ease,
-      box-shadow 220ms ease,
-      transform 160ms ease;
+      border-color 220ms ease,
+      background 240ms ease,
+      color 200ms ease,
+      box-shadow 320ms cubic-bezier(0.16, 1, 0.3, 1),
+      transform 320ms cubic-bezier(0.16, 1, 0.3, 1),
+      filter 220ms ease;
     overflow: hidden;
+    transform: translateY(0);
+    will-change: transform, box-shadow;
   }
 
   .question-option::before {
@@ -588,6 +594,8 @@
   .question-option--default:focus-visible {
     border-color: rgba(183, 146, 90, 0.45);
     box-shadow: 0 24px 55px rgba(var(--shadow-color) / 0.12);
+    transform: translateY(-4px) scale(1.01);
+    filter: saturate(1.05);
   }
 
   .question-option--default:hover::after,
@@ -619,12 +627,14 @@
   .question-option--selected:hover,
   .question-option--selected:focus-visible {
     box-shadow: 0 32px 70px rgba(var(--shadow-color) / 0.16);
+    transform: translateY(-3px) scale(1.01);
   }
 
   .question-option--disabled {
     opacity: 0.45;
     cursor: not-allowed;
     box-shadow: none;
+    transform: none !important;
   }
 
   .hero-headline {
@@ -760,14 +770,22 @@
     inset: -36%;
     border-radius: inherit;
     pointer-events: none;
-    background: radial-gradient(circle at 40% 30%, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
-    opacity: 0.22;
+    background: radial-gradient(circle at 40% 30%, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0));
+    opacity: 0.24;
   }
 
   .glass-card::after {
     inset: -42%;
-    background: radial-gradient(circle at 70% 80%, rgba(183, 146, 90, 0.18), rgba(255, 255, 255, 0));
-    opacity: 0.18;
+    background: radial-gradient(circle at 70% 80%, rgba(183, 146, 90, 0.22), rgba(255, 255, 255, 0));
+    opacity: 0.2;
+  }
+
+  .glass-card::before {
+    animation: aurora-shift 28s ease-in-out infinite alternate;
+  }
+
+  .glass-card::after {
+    animation: halo-glow 32s cubic-bezier(0.37, 0, 0.63, 1) infinite;
   }
 
   .glass-surface {
@@ -844,68 +862,135 @@ input.slider-thumb-accent::-moz-range-track {
   background-color: transparent;
 }
 @keyframes fade-in-up {
-  from {
+  0% {
     opacity: 0;
-    transform: translateY(22px) scale(0.98);
+    transform: translateY(28px) scale(0.985);
+    filter: blur(8px);
   }
-  to {
+  55% {
+    opacity: 1;
+    transform: translateY(-4px) scale(1.012);
+    filter: blur(0px);
+  }
+  100% {
     opacity: 1;
     transform: translateY(0) scale(1);
+    filter: blur(0px);
   }
 }
 
 @keyframes fade-in {
-  from {
+  0% {
     opacity: 0;
+    transform: translateY(12px);
+    filter: blur(6px);
   }
-  to {
+  100% {
     opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
   }
 }
 
 @keyframes slide-in-right {
-  from {
+  0% {
     opacity: 0;
-    transform: translateX(40px) scale(0.96);
+    transform: translate3d(42px, 0, 0) scale(0.96);
+    filter: blur(8px);
   }
-  to {
+  60% {
     opacity: 1;
-    transform: translateX(0) scale(1);
+    transform: translate3d(-4px, 0, 0) scale(1.01);
+    filter: blur(0px);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: blur(0px);
   }
 }
 
 @keyframes slide-in-left {
-  from {
+  0% {
     opacity: 0;
-    transform: translateX(-40px) scale(0.96);
+    transform: translate3d(-42px, 0, 0) scale(0.96);
+    filter: blur(8px);
   }
-  to {
+  60% {
     opacity: 1;
-    transform: translateX(0) scale(1);
+    transform: translate3d(4px, 0, 0) scale(1.01);
+    filter: blur(0px);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: blur(0px);
   }
 }
 
 @keyframes scale-in {
-  from {
+  0% {
     opacity: 0;
-    transform: scale(0.9);
+    transform: scale(0.92);
+    filter: blur(10px);
   }
-  to {
+  60% {
+    opacity: 1;
+    transform: scale(1.02);
+    filter: blur(0px);
+  }
+  100% {
     opacity: 1;
     transform: scale(1);
+    filter: blur(0px);
   }
 }
 
 @keyframes blur-in {
-  from {
+  0% {
     opacity: 0;
-    filter: blur(8px);
-    transform: scale(1.02);
+    filter: blur(14px) saturate(0.9);
+    transform: translateY(18px) scale(0.99);
   }
-  to {
+  65% {
     opacity: 1;
-    filter: blur(0);
-    transform: scale(1);
+    filter: blur(0px) saturate(1);
+    transform: translateY(-3px) scale(1.01);
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0px) saturate(1);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes aurora-shift {
+  0% {
+    transform: translate3d(-12%, -6%, 0) scale(0.98);
+    opacity: 0.18;
+  }
+  50% {
+    transform: translate3d(4%, 8%, 0) scale(1.05);
+    opacity: 0.28;
+  }
+  100% {
+    transform: translate3d(-6%, 2%, 0) scale(1.01);
+    opacity: 0.22;
+  }
+}
+
+@keyframes halo-glow {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1.02);
+    opacity: 0.18;
+  }
+  50% {
+    transform: translate3d(-4%, -6%, 0) scale(1.12);
+    opacity: 0.3;
+  }
+  100% {
+    transform: translate3d(6%, 4%, 0) scale(1.04);
+    opacity: 0.2;
   }
 }
 
@@ -921,52 +1006,52 @@ input.slider-thumb-accent::-moz-range-track {
 @layer utilities {
   .animate-fade-in {
     opacity: 0;
-    animation: fade-in 600ms ease forwards;
+    animation: fade-in 720ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
   }
 
   .animate-fade-in-up {
     opacity: 0;
-    animation: fade-in-up 700ms cubic-bezier(0.18, 0.62, 0.33, 0.98) forwards;
+    animation: fade-in-up 840ms cubic-bezier(0.19, 0.76, 0.32, 1) forwards;
   }
 
   .animate-slide-in-right {
     opacity: 0;
-    animation: slide-in-right 800ms cubic-bezier(0.16, 0.68, 0.32, 0.96) forwards;
+    animation: slide-in-right 900ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   }
 
   .animate-slide-in-left {
     opacity: 0;
-    animation: slide-in-left 800ms cubic-bezier(0.16, 0.68, 0.32, 0.96) forwards;
+    animation: slide-in-left 900ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   }
 
   .animate-scale-in {
     opacity: 0;
-    animation: scale-in 600ms cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+    animation: scale-in 720ms cubic-bezier(0.18, 0.84, 0.44, 1) forwards;
   }
 
   .animate-blur-in {
     opacity: 0;
-    animation: blur-in 900ms cubic-bezier(0.16, 0.68, 0.32, 0.96) forwards;
+    animation: blur-in 960ms cubic-bezier(0.2, 0.8, 0.3, 1) forwards;
   }
 
   .animate-delay-1 {
-    animation-delay: 120ms;
+    animation-delay: 140ms;
   }
 
   .animate-delay-2 {
-    animation-delay: 240ms;
+    animation-delay: 280ms;
   }
 
   .animate-delay-3 {
-    animation-delay: 360ms;
+    animation-delay: 420ms;
   }
 
   .animate-delay-4 {
-    animation-delay: 480ms;
+    animation-delay: 560ms;
   }
 
   .animate-delay-5 {
-    animation-delay: 600ms;
+    animation-delay: 700ms;
   }
 
   .loader-orbit {
@@ -1001,6 +1086,12 @@ input.slider-thumb-accent::-moz-range-track {
 
   .loader-orbit {
     animation: none;
+  }
+
+  .glass-card::before,
+  .glass-card::after {
+    animation: none !important;
+    transform: none !important;
   }
 }
 

--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -11,6 +11,19 @@ interface GradientCircle {
   color: string;
 }
 
+interface VeilLayer {
+  id: string;
+  gradient: string;
+  width: number;
+  height: number;
+  blur: string;
+  opacity: number;
+  rotate: number;
+  translateX: string;
+  translateY: string;
+  delay: number;
+}
+
 export default function AnimatedBackground() {
   const containerRef = useRef<HTMLDivElement>(null);
   const shouldReduceMotion = useReducedMotion();
@@ -18,24 +31,51 @@ export default function AnimatedBackground() {
   const circles: GradientCircle[] = [
     {
       id: 1,
-      x: 22,
-      y: 24,
-      size: 110,
-      color: "from-white/60 via-white/10 to-transparent",
+      x: 20,
+      y: 26,
+      size: 120,
+      color: "from-white/70 via-white/15 to-transparent",
     },
     {
       id: 2,
       x: 78,
-      y: 74,
-      size: 90,
-      color: "from-[#e6ddcf]/50 via-transparent to-transparent",
+      y: 72,
+      size: 95,
+      color: "from-[#eadfcf]/55 via-transparent to-transparent",
     },
     {
       id: 3,
-      x: 58,
+      x: 54,
       y: 32,
-      size: 70,
-      color: "from-[#ccb899]/40 via-transparent to-transparent",
+      size: 78,
+      color: "from-[#c8b090]/40 via-transparent to-transparent",
+    },
+  ];
+
+  const veils: VeilLayer[] = [
+    {
+      id: "veil-1",
+      gradient: "from-white/25 via-white/5 to-transparent",
+      width: 620,
+      height: 420,
+      blur: "blur-[120px]",
+      opacity: 0.25,
+      rotate: -8,
+      translateX: "-30%",
+      translateY: "-45%",
+      delay: 0,
+    },
+    {
+      id: "veil-2",
+      gradient: "from-[#cfae7a]/30 via-transparent to-transparent",
+      width: 540,
+      height: 460,
+      blur: "blur-[140px]",
+      opacity: 0.32,
+      rotate: 12,
+      translateX: "45%",
+      translateY: "55%",
+      delay: 3.2,
     },
   ];
 
@@ -43,18 +83,22 @@ export default function AnimatedBackground() {
     <div ref={containerRef} className="pointer-events-none absolute inset-0 overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-[#f9f9f7] via-[#f3f1ec] to-[#ece8e0]" />
       {circles.map((circle, index) => {
+        const baseStyle = {
+          width: `${circle.size * 3.6}px`,
+          height: `${circle.size * 3.6}px`,
+        };
+
         if (shouldReduceMotion) {
           return (
             <div
               key={circle.id}
-              className={`absolute rounded-full blur-[70px] bg-gradient-to-br ${circle.color}`}
+              className={`absolute rounded-full blur-[80px] bg-gradient-to-br ${circle.color}`}
               style={{
                 left: `${circle.x}%`,
                 top: `${circle.y}%`,
-                width: `${circle.size * 3.5}px`,
-                height: `${circle.size * 3.5}px`,
-                transform: "translate(-50%, -50%)",
+                transform: "translate(-50%, -50%) scale(1)",
                 opacity: 0.28,
+                ...baseStyle,
               }}
             />
           );
@@ -63,28 +107,77 @@ export default function AnimatedBackground() {
         return (
           <motion.div
             key={circle.id}
-            className={`absolute rounded-full blur-[70px] bg-gradient-to-br ${circle.color}`}
-            style={{
-              left: 0,
-              top: 0,
-              transform: "translate(-50%, -50%)",
-            }}
+            className={`absolute rounded-full blur-[80px] bg-gradient-to-br ${circle.color}`}
+            style={{ left: 0, top: 0, transform: "translate(-50%, -50%)" }}
             initial={{
               x: `${circle.x}%`,
               y: `${circle.y}%`,
-              width: `${circle.size * 3.5}px`,
-              height: `${circle.size * 3.5}px`,
-              opacity: 0.28,
+              opacity: 0.26,
+              ...baseStyle,
             }}
             animate={{
-              x: [`${circle.x}%`, `${circle.x + 8}%`, `${circle.x - 5}%`, `${circle.x}%`],
-              y: [`${circle.y}%`, `${circle.y - 6}%`, `${circle.y + 8}%`, `${circle.y}%`],
-              opacity: [0.24, 0.3, 0.27, 0.24],
+              x: [`${circle.x}%`, `${circle.x + 7}%`, `${circle.x - 4}%`, `${circle.x}%`],
+              y: [`${circle.y}%`, `${circle.y - 5}%`, `${circle.y + 7}%`, `${circle.y}%`],
+              opacity: [0.22, 0.3, 0.26, 0.24],
+              scale: [1, 1.04, 0.98, 1],
             }}
-            transition={{ duration: 18 + index * 3, repeat: Infinity, ease: "easeInOut" }}
+            transition={{
+              duration: 22 + index * 4,
+              repeat: Infinity,
+              ease: [0.4, 0, 0.2, 1],
+            }}
           />
         );
       })}
+
+      {shouldReduceMotion
+        ? null
+        : veils.map((veil) => (
+            <motion.div
+              key={veil.id}
+              className={`absolute ${veil.blur} bg-gradient-to-br ${veil.gradient} mix-blend-screen`}
+              style={{
+                width: veil.width,
+                height: veil.height,
+                left: "50%",
+                top: "50%",
+                opacity: veil.opacity,
+                transform: `translate(${veil.translateX}, ${veil.translateY}) rotate(${veil.rotate}deg)`,
+              }}
+              animate={{
+                rotate: [veil.rotate, veil.rotate + 4, veil.rotate - 6, veil.rotate],
+                opacity: [veil.opacity * 0.7, veil.opacity, veil.opacity * 0.85],
+              }}
+              transition={{
+                duration: 26,
+                repeat: Infinity,
+                ease: [0.45, 0, 0.2, 1],
+                delay: veil.delay,
+              }}
+            />
+          ))}
+
+      {!shouldReduceMotion && (
+        <>
+          <motion.div
+            className="absolute left-1/2 top-[-22%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-gradient-to-b from-white/50 via-white/5 to-transparent blur-[90px] mix-blend-screen"
+            animate={{
+              scale: [1.1, 1.16, 1.08, 1.1],
+              opacity: [0.25, 0.32, 0.26, 0.25],
+            }}
+            transition={{ duration: 18, repeat: Infinity, ease: [0.4, 0, 0.2, 1] }}
+          />
+          <motion.div
+            className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.22),rgba(255,255,255,0))]"
+            animate={{
+              backgroundPosition: ["0% 0%", "40% 20%", "20% 60%", "0% 0%"],
+              opacity: [0.2, 0.32, 0.24, 0.2],
+            }}
+            transition={{ duration: 28, repeat: Infinity, ease: [0.45, 0, 0.25, 1] }}
+            style={{ mixBlendMode: "soft-light" }}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/KioskFrame.tsx
+++ b/src/components/KioskFrame.tsx
@@ -2,6 +2,7 @@
 
 import React, { startTransition, useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import AnimatedBackground from "@/components/AnimatedBackground";
 
 const IDLE_TIMEOUT_MS = 30_000;
@@ -17,6 +18,7 @@ export default function KioskFrame({
   const pathname = usePathname();
   const idleTimerRef = useRef<number | null>(null);
   const isHome = pathname === "/";
+  const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
     if (typeof window === "undefined" || isHome) {
@@ -91,7 +93,30 @@ export default function KioskFrame({
   return (
     <div className="kiosk-root">
       <AnimatedBackground />
-      <div className={`kiosk-frame ${className}`}>{children}</div>
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={shouldReduceMotion ? "static" : pathname}
+          className={`kiosk-frame ${className}`}
+          initial={
+            shouldReduceMotion
+              ? false
+              : { opacity: 0, y: 22, scale: 0.988, filter: "blur(6px)" }
+          }
+          animate={
+            shouldReduceMotion
+              ? { opacity: 1 }
+              : { opacity: 1, y: 0, scale: 1, filter: "blur(0px)" }
+          }
+          exit={
+            shouldReduceMotion
+              ? { opacity: 1 }
+              : { opacity: 0, y: -16, scale: 0.99, filter: "blur(6px)" }
+          }
+          transition={{ duration: 0.55, ease: [0.22, 0.61, 0.36, 1] }}
+        >
+          {children}
+        </motion.div>
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/TapIndicator.tsx
+++ b/src/components/TapIndicator.tsx
@@ -1,4 +1,7 @@
-﻿import React from "react";
+"use client";
+
+import React, { useId } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 
 interface TapIndicatorProps {
   size?: number;
@@ -13,34 +16,102 @@ export default function TapIndicator({
   strokeWidth = 3,
   className = "",
 }: TapIndicatorProps) {
+  const gradientId = useId();
+  const shouldReduceMotion = useReducedMotion();
+
+  if (shouldReduceMotion) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 100 100"
+        className={className}
+        aria-hidden
+      >
+        <defs>
+          <radialGradient id={gradientId} cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor={color} stopOpacity="0.35" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        <circle cx="50" cy="50" r="6" fill={color} />
+        <circle cx="50" cy="50" r="36" fill={`url(#${gradientId})`} opacity={0.4} />
+        <circle
+          cx="50"
+          cy="50"
+          r="32"
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeOpacity={0.35}
+        />
+      </svg>
+    );
+  }
+
+  const ripples = [0, 0.55, 1.1];
+
   return (
-    <svg
+    <motion.svg
       width={size}
       height={size}
-      viewBox="0 0 100  100"
+      viewBox="0 0 100 100"
       className={className}
       aria-hidden
+      initial={{ opacity: 0, scale: 0.94 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.55, ease: [0.22, 0.61, 0.36, 1] }}
     >
       <defs>
-        <radialGradient id="tap-fade" cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stopColor={color} stopOpacity="0.35" />
+        <radialGradient id={gradientId} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor={color} stopOpacity="0.4" />
           <stop offset="100%" stopColor={color} stopOpacity="0" />
         </radialGradient>
       </defs>
 
-      <circle cx="50" cy="50" r="6" fill={color} />
+      <motion.circle
+        cx="50"
+        cy="50"
+        r="38"
+        fill={`url(#${gradientId})`}
+        initial={{ opacity: 0.3 }}
+        animate={{ opacity: [0.32, 0.46, 0.32] }}
+        transition={{ duration: 3.4, repeat: Infinity, ease: [0.45, 0, 0.2, 1] }}
+      />
 
-      <circle cx="50" cy="50" r="20" fill="none" stroke={color} strokeWidth={strokeWidth} strokeOpacity="0.8">
-        <animate attributeName="r" values="20;44" dur="1.8s" repeatCount="indefinite" />
-        <animate attributeName="opacity" values="0.8;0" dur="1.8s" repeatCount="indefinite" />
-      </circle>
+      {ripples.map((delay) => (
+        <motion.circle
+          key={delay}
+          cx="50"
+          cy="50"
+          r="24"
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeOpacity={0.75}
+          style={{ originX: "50%", originY: "50%" }}
+          initial={{ scale: 0.6, opacity: 0.75 }}
+          animate={{ scale: 1.45, opacity: 0 }}
+          transition={{
+            duration: 2.4,
+            repeat: Infinity,
+            repeatDelay: 0.2,
+            ease: [0.16, 1, 0.3, 1],
+            delay,
+          }}
+        />
+      ))}
 
-      <circle cx="50" cy="50" r="20" fill="none" stroke={color} strokeWidth={strokeWidth} strokeOpacity="0.8">
-        <animate attributeName="r" values="20;44" dur="1.8s" begin="-0.9s" repeatCount="indefinite" />
-        <animate attributeName="opacity" values="0.8;0" dur="1.8s" begin="-0.9s" repeatCount="indefinite" />
-      </circle>
-
-      <circle cx="50" cy="50" r="44" fill="url(#tap-fade)" />
-    </svg>
+      <motion.circle
+        cx="50"
+        cy="50"
+        r="8"
+        fill={color}
+        initial={{ scale: 0.92 }}
+        animate={{ scale: [0.95, 1.1, 0.95] }}
+        transition={{ duration: 1.8, repeat: Infinity, ease: [0.45, 0, 0.2, 1] }}
+      />
+    </motion.svg>
   );
 }


### PR DESCRIPTION
## Summary
- add route-aware transition wrapper inside the kiosk frame so every view fades and lifts in with reduced-motion safeguards
- enrich the animated background, tap indicator, and glass surfaces with layered, slow-moving gradients for a premium kiosk ambience
- retune global motion tokens so buttons and questionnaire options glide with Apple-like easing while respecting reduced-motion users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d506569ccc832081c3ede28ecf6c08