### PR TITLE
Add Strapi admin API helpers and admin panel UI

### DIFF
--- a/src/app/admin/brands/page.tsx
+++ b/src/app/admin/brands/page.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+import {
+  createBrand,
+  fetchBrandsAdmin,
+  type AdminBrand,
+  type CreateBrandPayload,
+} from "@/lib/admin-api";
+
+type FeedbackState = {
+  type: "success" | "error";
+  message: string;
+};
+
+interface BrandFormValues {
+  nameFa: string;
+  nameEn: string;
+  description?: string;
+  slug?: string;
+  website?: string;
+}
+
+const defaultValues: BrandFormValues = {
+  nameFa: "",
+  nameEn: "",
+  description: "",
+  slug: "",
+  website: "",
+};
+
+const buildPayload = (values: BrandFormValues): CreateBrandPayload => ({
+  name_fa: values.nameFa.trim(),
+  name_en: values.nameEn.trim(),
+  description: values.description?.trim() || undefined,
+  slug: values.slug?.trim() || undefined,
+  website: values.website?.trim() || undefined,
+});
+
+export default function AdminBrandsPage() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<BrandFormValues>({ defaultValues });
+  const [brands, setBrands] = useState<AdminBrand[]>([]);
+  const [status, setStatus] = useState<FeedbackState | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const loadBrands = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchBrandsAdmin();
+      setBrands(data);
+    } catch (error) {
+      console.error("خطا در بارگذاری برندها", error);
+      setStatus({
+        type: "error",
+        message: "بارگذاری برندها با خطا مواجه شد. اتصال و توکن را بررسی کنید.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadBrands();
+  }, [loadBrands]);
+
+  const onSubmit = async (values: BrandFormValues) => {
+    setStatus(null);
+
+    try {
+      const payload = buildPayload(values);
+      await createBrand(payload);
+      setStatus({ type: "success", message: "برند جدید با موفقیت ثبت شد." });
+      reset(defaultValues);
+      await loadBrands();
+    } catch (error) {
+      console.error("خطا در ثبت برند", error);
+      setStatus({ type: "error", message: "ثبت برند انجام نشد. لطفاً دوباره تلاش کنید." });
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-10" dir="rtl">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold">برندها</h2>
+        <p className="text-[var(--color-foreground-muted)]">
+          لیست برندهای موجود را مشاهده کنید و برند تازه‌ای به سامانه اضافه نمایید.
+        </p>
+      </div>
+
+      <form
+        className="space-y-6 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background-soft)]/70 p-6 shadow-[var(--shadow-soft)]"
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="nameFa">
+              نام فارسی <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="nameFa"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً شنل"
+              {...register("nameFa", { required: "نام فارسی الزامی است." })}
+            />
+            {errors.nameFa && (
+              <span className="text-xs text-red-500">{errors.nameFa.message}</span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="nameEn">
+              نام انگلیسی <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="nameEn"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً Chanel"
+              {...register("nameEn", { required: "نام انگلیسی الزامی است." })}
+            />
+            {errors.nameEn && (
+              <span className="text-xs text-red-500">{errors.nameEn.message}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="slug">
+              اسلاگ (اختیاری)
+            </label>
+            <input
+              id="slug"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً chanel"
+              {...register("slug")}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="website">
+              وب‌سایت (اختیاری)
+            </label>
+            <input
+              id="website"
+              type="url"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="https://example.com"
+              {...register("website", {
+                pattern: {
+                  value: /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[^\s]*)?$/i,
+                  message: "آدرس وارد شده معتبر نیست.",
+                },
+              })}
+            />
+            {errors.website && (
+              <span className="text-xs text-red-500">{errors.website.message}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="description">
+            توضیحات (اختیاری)
+          </label>
+          <textarea
+            id="description"
+            className="min-h-[120px] rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+            placeholder="توضیحات تکمیلی برند را اینجا بنویسید..."
+            {...register("description")}
+          />
+        </div>
+
+        {status && (
+          <div
+            className={`rounded-[var(--radius-base)] px-4 py-3 text-sm ${
+              status.type === "success"
+                ? "bg-green-100 text-green-800"
+                : "bg-red-100 text-red-800"
+            }`}
+          >
+            {status.message}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-[var(--radius-base)] bg-[var(--color-accent)] px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-[var(--color-accent-strong)] disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isSubmitting ? "در حال ارسال..." : "ثبت برند"}
+          </button>
+        </div>
+      </form>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-semibold">لیست برندهای موجود</h3>
+          {loading && <span className="text-sm text-[var(--color-foreground-muted)]">در حال بارگذاری...</span>}
+        </div>
+        {brands.length === 0 && !loading ? (
+          <p className="text-sm text-[var(--color-foreground-muted)]">هنوز برندی ثبت نشده است.</p>
+        ) : (
+          <ul className="grid gap-3 md:grid-cols-2">
+            {brands.map((brand) => (
+              <li
+                key={brand.id}
+                className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-[var(--color-background-soft)]/70 p-4 text-sm shadow-[var(--shadow-soft)]"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="font-semibold text-[var(--color-foreground)]">{brand.name_fa}</p>
+                  <span className="text-xs text-[var(--color-foreground-subtle)]">{brand.name_en}</span>
+                </div>
+                {brand.description && (
+                  <p className="mt-2 text-[var(--color-foreground-muted)] leading-relaxed">{brand.description}</p>
+                )}
+                {brand.website && (
+                  <a
+                    href={brand.website.startsWith("http") ? brand.website : `https://${brand.website}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-3 inline-flex text-xs font-medium text-[var(--color-accent-strong)]"
+                  >
+                    مشاهده وب‌سایت ↗
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/admin/collections/page.tsx
+++ b/src/app/admin/collections/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+import {
+  createCollection,
+  fetchBrandsAdmin,
+  fetchCollectionsAdmin,
+  type AdminBrand,
+  type AdminCollection,
+  type CreateCollectionPayload,
+} from "@/lib/admin-api";
+
+type FeedbackState = {
+  type: "success" | "error";
+  message: string;
+};
+
+interface CollectionFormValues {
+  nameFa: string;
+  nameEn: string;
+  brandId?: string;
+  description?: string;
+  slug?: string;
+}
+
+const defaultValues: CollectionFormValues = {
+  nameFa: "",
+  nameEn: "",
+  brandId: "",
+  description: "",
+  slug: "",
+};
+
+const buildPayload = (values: CollectionFormValues): CreateCollectionPayload => ({
+  name_fa: values.nameFa.trim(),
+  name_en: values.nameEn.trim(),
+  description: values.description?.trim() || undefined,
+  slug: values.slug?.trim() || undefined,
+  brand: values.brandId ? Number(values.brandId) : undefined,
+});
+
+export default function AdminCollectionsPage() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<CollectionFormValues>({ defaultValues });
+  const [brands, setBrands] = useState<AdminBrand[]>([]);
+  const [collections, setCollections] = useState<AdminCollection[]>([]);
+  const [status, setStatus] = useState<FeedbackState | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [brandData, collectionData] = await Promise.all([
+        fetchBrandsAdmin(),
+        fetchCollectionsAdmin(),
+      ]);
+      setBrands(brandData);
+      setCollections(collectionData);
+    } catch (error) {
+      console.error("خطا در بارگذاری کالکشن‌ها", error);
+      setStatus({
+        type: "error",
+        message: "بارگذاری داده‌ها با خطا مواجه شد. لطفاً دوباره تلاش کنید.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const onSubmit = async (values: CollectionFormValues) => {
+    setStatus(null);
+
+    try {
+      const payload = buildPayload(values);
+      await createCollection(payload);
+      setStatus({ type: "success", message: "کالکشن جدید با موفقیت ثبت شد." });
+      reset(defaultValues);
+      await loadData();
+    } catch (error) {
+      console.error("خطا در ثبت کالکشن", error);
+      setStatus({ type: "error", message: "ثبت کالکشن انجام نشد. مجدداً تلاش کنید." });
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-10" dir="rtl">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold">کالکشن‌ها</h2>
+        <p className="text-[var(--color-foreground-muted)]">
+          کالکشن‌های برندهای مختلف را مدیریت کنید و دسته‌بندی‌های تازه بسازید.
+        </p>
+      </div>
+
+      <form
+        className="space-y-6 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background-soft)]/70 p-6 shadow-[var(--shadow-soft)]"
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="nameFa">
+              نام فارسی <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="nameFa"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً کالکشن اختصاصی"
+              {...register("nameFa", { required: "نام فارسی الزامی است." })}
+            />
+            {errors.nameFa && (
+              <span className="text-xs text-red-500">{errors.nameFa.message}</span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="nameEn">
+              نام انگلیسی <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="nameEn"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً Exclusive Collection"
+              {...register("nameEn", { required: "نام انگلیسی الزامی است." })}
+            />
+            {errors.nameEn && (
+              <span className="text-xs text-red-500">{errors.nameEn.message}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="brandId">
+              برند مرتبط
+            </label>
+            <select
+              id="brandId"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              {...register("brandId")}
+            >
+              <option value="">انتخاب نشده</option>
+              {brands.map((brand) => (
+                <option key={brand.id} value={brand.id}>
+                  {brand.name_fa} ({brand.name_en})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="slug">
+              اسلاگ (اختیاری)
+            </label>
+            <input
+              id="slug"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً exclusive"
+              {...register("slug")}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="description">
+            توضیحات (اختیاری)
+          </label>
+          <textarea
+            id="description"
+            className="min-h-[120px] rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+            placeholder="توضیحات یا جزئیات کالکشن را درج کنید..."
+            {...register("description")}
+          />
+        </div>
+
+        {status && (
+          <div
+            className={`rounded-[var(--radius-base)] px-4 py-3 text-sm ${
+              status.type === "success"
+                ? "bg-green-100 text-green-800"
+                : "bg-red-100 text-red-800"
+            }`}
+          >
+            {status.message}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-[var(--radius-base)] bg-[var(--color-accent)] px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-[var(--color-accent-strong)] disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isSubmitting ? "در حال ارسال..." : "ثبت کالکشن"}
+          </button>
+        </div>
+      </form>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-semibold">لیست کالکشن‌های موجود</h3>
+          {loading && <span className="text-sm text-[var(--color-foreground-muted)]">در حال بارگذاری...</span>}
+        </div>
+        {collections.length === 0 && !loading ? (
+          <p className="text-sm text-[var(--color-foreground-muted)]">هنوز کالکشنی ثبت نشده است.</p>
+        ) : (
+          <ul className="grid gap-3 md:grid-cols-2">
+            {collections.map((collection) => (
+              <li
+                key={collection.id}
+                className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-[var(--color-background-soft)]/70 p-4 text-sm shadow-[var(--shadow-soft)]"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="font-semibold text-[var(--color-foreground)]">{collection.name_fa}</p>
+                  <span className="text-xs text-[var(--color-foreground-subtle)]">{collection.name_en}</span>
+                </div>
+                {collection.brand && (
+                  <p className="mt-1 text-xs text-[var(--color-foreground-muted)]">
+                    برند: {collection.brand.name_fa} ({collection.brand.name_en})
+                  </p>
+                )}
+                {collection.description && (
+                  <p className="mt-2 text-[var(--color-foreground-muted)] leading-relaxed">{collection.description}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+const navigationLinks = [
+  { href: "/admin/products", label: "محصولات" },
+  { href: "/admin/brands", label: "برندها" },
+  { href: "/admin/collections", label: "کالکشن‌ها" },
+];
+
+export default function AdminLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  const pathname = usePathname();
+
+  return (
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-foreground)]" dir="rtl">
+      <header className="border-b border-[var(--color-border)]/70 bg-[var(--color-surface)]/90 backdrop-blur-xl shadow-[var(--shadow-soft)]">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-6 py-8">
+          <p className="text-sm text-[var(--color-foreground-subtle)]">مدیریت محتوا</p>
+          <h1 className="text-3xl font-semibold">پنل مدیریت گندم پرفیوم</h1>
+          <p className="text-[var(--color-foreground-muted)]">
+            از این بخش می‌توانید محصولات، برندها و کالکشن‌ها را مدیریت کنید.
+          </p>
+        </div>
+      </header>
+
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-10 lg:flex-row">
+        <nav className="flex flex-row gap-3 overflow-x-auto rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)]/70 p-3 shadow-[var(--shadow-soft)] lg:h-fit lg:w-64 lg:flex-col">
+          {navigationLinks.map((item) => {
+            const active = pathname === item.href || pathname?.startsWith(`${item.href}/`);
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex items-center justify-between rounded-[var(--radius-base)] px-4 py-3 text-sm transition-all ${
+                  active
+                    ? "bg-[var(--color-accent)] text-white shadow-[var(--shadow-strong)]"
+                    : "bg-transparent text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)]"
+                }`}
+              >
+                <span>{item.label}</span>
+                {active && <span className="text-xs">فعال</span>}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <main className="flex-1 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)]/95 p-6 shadow-[var(--shadow-soft)] lg:p-10">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+
+const quickLinks = [
+  {
+    href: "/admin/products",
+    title: "مدیریت محصولات",
+    description: "افزودن عطر جدید، به‌روزرسانی اطلاعات و مدیریت نت‌ها.",
+  },
+  {
+    href: "/admin/brands",
+    title: "مدیریت برندها",
+    description: "ساخت برند جدید یا ویرایش برندهای موجود.",
+  },
+  {
+    href: "/admin/collections",
+    title: "مدیریت کالکشن‌ها",
+    description: "تعریف کالکشن‌های تازه و دسته‌بندی محصولات.",
+  },
+];
+
+export default function AdminDashboardPage() {
+  return (
+    <section className="flex flex-col gap-10" dir="rtl">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold">داشبورد مدیریتی</h2>
+        <p className="text-[var(--color-foreground-muted)]">
+          خوش آمدید! از اینجا می‌توانید محتوای وب‌سایت و کیوسک را به‌صورت یکپارچه مدیریت کنید.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {quickLinks.map((card) => (
+          <Link
+            key={card.href}
+            href={card.href}
+            className="group relative overflow-hidden rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background-soft)]/80 p-6 transition-all hover:-translate-y-1 hover:shadow-[var(--shadow-strong)]"
+          >
+            <div className="flex h-full flex-col gap-3">
+              <h3 className="text-xl font-semibold text-[var(--color-foreground)] transition-colors group-hover:text-[var(--color-accent-strong)]">
+                {card.title}
+              </h3>
+              <p className="text-sm text-[var(--color-foreground-muted)]">{card.description}</p>
+              <span className="mt-auto inline-flex items-center gap-2 text-sm font-medium text-[var(--color-accent-strong)]">
+                ورود به صفحه <span aria-hidden>↗</span>
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      <div className="rounded-[var(--radius-lg)] border border-dashed border-[var(--color-border)] bg-[var(--color-background-soft)]/60 p-6 text-sm text-[var(--color-foreground-muted)]">
+        <p className="font-medium text-[var(--color-foreground)]">راهنمای سریع</p>
+        <ul className="mt-3 list-disc space-y-2 pr-5">
+          <li>برای ثبت عطر جدید ابتدا مطمئن شوید برند و کالکشن آن در سامانه وجود دارد.</li>
+          <li>پس از هر بار ثبت یا ویرایش، چند ثانیه صبر کنید تا لیست‌ها به‌روزرسانی شوند.</li>
+          <li>در صورت بروز خطا، اتصال به اینترنت و توکن دسترسی را بررسی کنید.</li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -1,0 +1,558 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import {
+  createPerfume,
+  fetchBrandsAdmin,
+  fetchCollectionsAdmin,
+  fetchPerfumesAdmin,
+  type AdminBrand,
+  type AdminCollection,
+  type AdminPerfume,
+  type CreatePerfumePayload,
+  type PerfumeNotes,
+} from "@/lib/admin-api";
+
+type FeedbackState = {
+  type: "success" | "error";
+  message: string;
+};
+
+interface PerfumeFormValues {
+  nameFa: string;
+  nameEn: string;
+  brandId: string;
+  collectionId: string;
+  gender: string;
+  season: string;
+  family: string;
+  character: string;
+  description?: string;
+  notes: PerfumeNotes;
+}
+
+const genderOptions = ["زنانه", "مردانه", "یونیسکس"];
+const seasonOptions = ["بهار", "تابستان", "پاییز", "زمستان", "چهارفصل"];
+const familyOptions = ["گلی", "چوبی", "شرقی", "مرکباتی", "آروماتیک", "مشکدار"];
+const characterOptions = ["رسمی", "روزمره", "رمانتیک", "اسپرت", "جذاب", "کلاسیک"];
+
+const createDefaultValues = (): PerfumeFormValues => ({
+  nameFa: "",
+  nameEn: "",
+  brandId: "",
+  collectionId: "",
+  gender: "",
+  season: "",
+  family: "",
+  character: "",
+  description: "",
+  notes: {
+    top: [],
+    middle: [],
+    base: [],
+  },
+});
+
+const normaliseNotes = (items: string[]): string[] =>
+  Array.from(
+    new Set(
+      items
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0)
+        .map((item) => item.replace(/\s+/g, " ")),
+    ),
+  );
+
+interface NotesFieldProps {
+  label: string;
+  helper: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+  error?: string;
+}
+
+function NotesField({ label, helper, value, onChange, error }: NotesFieldProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  const handleAdd = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    if (!value.includes(trimmed)) {
+      onChange([...value, trimmed]);
+    }
+    setInputValue("");
+  };
+
+  const handleRemove = (note: string) => {
+    onChange(value.filter((item) => item !== note));
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium text-[var(--color-foreground)]">{label}</label>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              handleAdd();
+            }
+          }}
+          className="flex-1 rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+          placeholder="مثلاً ترنج"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="rounded-[var(--radius-base)] bg-[var(--color-accent)] px-4 py-2 text-sm font-semibold text-white transition-all hover:bg-[var(--color-accent-strong)]"
+        >
+          افزودن
+        </button>
+      </div>
+      <p className="text-xs text-[var(--color-foreground-muted)]">{helper}</p>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {value.map((note) => (
+            <span
+              key={note}
+              className="inline-flex items-center gap-2 rounded-full bg-[var(--color-accent-soft)] px-3 py-1 text-xs text-[var(--color-accent-contrast)]"
+            >
+              {note}
+              <button
+                type="button"
+                onClick={() => handleRemove(note)}
+                className="text-[var(--color-accent-contrast)]/70 transition hover:text-[var(--color-accent-contrast)]"
+                aria-label={`حذف ${note}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      {error && <span className="text-xs text-red-500">{error}</span>}
+    </div>
+  );
+}
+
+export default function AdminProductsPage() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<PerfumeFormValues>({ defaultValues: createDefaultValues() });
+
+  const [brands, setBrands] = useState<AdminBrand[]>([]);
+  const [collections, setCollections] = useState<AdminCollection[]>([]);
+  const [perfumes, setPerfumes] = useState<AdminPerfume[]>([]);
+  const [status, setStatus] = useState<FeedbackState | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [brandData, collectionData, perfumeData] = await Promise.all([
+        fetchBrandsAdmin(),
+        fetchCollectionsAdmin(),
+        fetchPerfumesAdmin(),
+      ]);
+      setBrands(brandData);
+      setCollections(collectionData);
+      setPerfumes(perfumeData);
+    } catch (error) {
+      console.error("خطا در بارگذاری داده‌های محصول", error);
+      setStatus({
+        type: "error",
+        message: "بارگذاری داده‌ها با خطا مواجه شد. دوباره تلاش کنید.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const selectedBrandId = watch("brandId");
+  const selectedCollectionId = watch("collectionId");
+
+  const availableCollections = useMemo(() => {
+    if (!selectedBrandId) {
+      return collections;
+    }
+
+    return collections.filter((collection) =>
+      collection.brand ? collection.brand.id.toString() === selectedBrandId : false,
+    );
+  }, [collections, selectedBrandId]);
+
+  useEffect(() => {
+    if (!selectedCollectionId) {
+      return;
+    }
+
+    const exists = availableCollections.some(
+      (collection) => collection.id.toString() === selectedCollectionId,
+    );
+
+    if (!exists) {
+      setValue("collectionId", "");
+    }
+  }, [availableCollections, selectedCollectionId, setValue]);
+
+  const onSubmit = async (values: PerfumeFormValues) => {
+    setStatus(null);
+
+    try {
+      const payload: CreatePerfumePayload = {
+        name_fa: values.nameFa.trim(),
+        name_en: values.nameEn.trim(),
+        description: values.description?.trim() || undefined,
+        gender: values.gender || undefined,
+        season: values.season || undefined,
+        family: values.family || undefined,
+        character: values.character || undefined,
+        notes: {
+          top: normaliseNotes(values.notes.top),
+          middle: normaliseNotes(values.notes.middle),
+          base: normaliseNotes(values.notes.base),
+        },
+        brand: Number(values.brandId),
+        collection: values.collectionId ? Number(values.collectionId) : undefined,
+      };
+
+      await createPerfume(payload);
+      setStatus({ type: "success", message: "محصول جدید با موفقیت ثبت شد." });
+      reset(createDefaultValues());
+      await loadData();
+    } catch (error) {
+      console.error("خطا در ثبت محصول", error);
+      setStatus({
+        type: "error",
+        message: "ثبت محصول با خطا مواجه شد. مقادیر فرم را بررسی و مجدداً تلاش کنید.",
+      });
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-10" dir="rtl">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold">محصولات / عطرها</h2>
+        <p className="text-[var(--color-foreground-muted)]">
+          اطلاعات کامل عطرهای فروشگاه را وارد کنید و ارتباط آن‌ها را با برند و کالکشن مشخص نمایید.
+        </p>
+      </div>
+
+      <form
+        className="space-y-6 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background-soft)]/70 p-6 shadow-[var(--shadow-soft)]"
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="nameFa">
+              نام فارسی <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="nameFa"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً افسانه شرقی"
+              {...register("nameFa", { required: "نام فارسی الزامی است." })}
+            />
+            {errors.nameFa && (
+              <span className="text-xs text-red-500">{errors.nameFa.message}</span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="nameEn">
+              نام انگلیسی <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="nameEn"
+              type="text"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              placeholder="مثلاً Oriental Tale"
+              {...register("nameEn", { required: "نام انگلیسی الزامی است." })}
+            />
+            {errors.nameEn && (
+              <span className="text-xs text-red-500">{errors.nameEn.message}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="brandId">
+              برند مرتبط <span className="text-red-500">*</span>
+            </label>
+            <select
+              id="brandId"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              {...register("brandId", { required: "انتخاب برند الزامی است." })}
+            >
+              <option value="">یک برند را انتخاب کنید</option>
+              {brands.map((brand) => (
+                <option key={brand.id} value={brand.id}>
+                  {brand.name_fa} ({brand.name_en})
+                </option>
+              ))}
+            </select>
+            {errors.brandId && (
+              <span className="text-xs text-red-500">{errors.brandId.message}</span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="collectionId">
+              کالکشن مرتبط
+            </label>
+            <select
+              id="collectionId"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              {...register("collectionId")}
+            >
+              <option value="">انتخاب نشده</option>
+              {availableCollections.map((collection) => (
+                <option key={collection.id} value={collection.id}>
+                  {collection.name_fa}
+                  {collection.brand && ` - ${collection.brand.name_fa}`}
+                </option>
+              ))}
+            </select>
+            {selectedBrandId && availableCollections.length === 0 && (
+              <span className="text-xs text-[var(--color-foreground-muted)]">
+                برای این برند کالکشنی ثبت نشده است.
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="gender">
+              جنسیت هدف
+            </label>
+            <select
+              id="gender"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              {...register("gender")}
+            >
+              <option value="">انتخاب نشده</option>
+              {genderOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="season">
+              فصل پیشنهادی
+            </label>
+            <select
+              id="season"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              {...register("season")}
+            >
+              <option value="">انتخاب نشده</option>
+              {seasonOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="family">
+              خانواده عطری
+            </label>
+            <select
+              id="family"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              {...register("family")}
+            >
+              <option value="">انتخاب نشده</option>
+              {familyOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="character">
+              کاراکتر / حس کلی
+            </label>
+            <select
+              id="character"
+              className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+              {...register("character")}
+            >
+              <option value="">انتخاب نشده</option>
+              {characterOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-[var(--color-foreground)]" htmlFor="description">
+            توضیحات تکمیلی
+          </label>
+          <textarea
+            id="description"
+            className="min-h-[140px] rounded-[var(--radius-base)] border border-[var(--color-border)] bg-white px-4 py-3 text-sm text-[var(--color-foreground)] focus:border-[var(--color-accent)] focus:outline-none"
+            placeholder="توضیحات و نکات برجسته محصول را بنویسید..."
+            {...register("description")}
+          />
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          <Controller
+            control={control}
+            name="notes.top"
+            rules={{ validate: (value) => value.length > 0 || "حداقل یک نت بالایی وارد کنید." }}
+            render={({ field, fieldState }) => (
+              <NotesField
+                label="نت‌های آغازین"
+                helper="نام نت را تایپ کرده و دکمه افزودن را بزنید."
+                value={field.value ?? []}
+                onChange={field.onChange}
+                error={fieldState.error?.message}
+              />
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="notes.middle"
+            rules={{ validate: (value) => value.length > 0 || "حداقل یک نت میانی وارد کنید." }}
+            render={({ field, fieldState }) => (
+              <NotesField
+                label="نت‌های میانی"
+                helper="برای جداکردن نت‌ها از دکمه افزودن استفاده کنید."
+                value={field.value ?? []}
+                onChange={field.onChange}
+                error={fieldState.error?.message}
+              />
+            )}
+          />
+
+          <Controller
+            control={control}
+            name="notes.base"
+            rules={{ validate: (value) => value.length > 0 || "حداقل یک نت پایانی وارد کنید." }}
+            render={({ field, fieldState }) => (
+              <NotesField
+                label="نت‌های پایانی"
+                helper="می‌توانید هر تعداد نت که می‌خواهید اضافه کنید."
+                value={field.value ?? []}
+                onChange={field.onChange}
+                error={fieldState.error?.message}
+              />
+            )}
+          />
+        </div>
+
+        {status && (
+          <div
+            className={`rounded-[var(--radius-base)] px-4 py-3 text-sm ${
+              status.type === "success"
+                ? "bg-green-100 text-green-800"
+                : "bg-red-100 text-red-800"
+            }`}
+          >
+            {status.message}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-[var(--radius-base)] bg-[var(--color-accent)] px-6 py-3 text-sm font-semibold text-white transition-all hover:bg-[var(--color-accent-strong)] disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isSubmitting ? "در حال ارسال..." : "ثبت محصول"}
+          </button>
+        </div>
+      </form>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-semibold">آخرین محصولات ثبت‌شده</h3>
+          {loading && <span className="text-sm text-[var(--color-foreground-muted)]">در حال بارگذاری...</span>}
+        </div>
+        {perfumes.length === 0 && !loading ? (
+          <p className="text-sm text-[var(--color-foreground-muted)]">هنوز محصولی ثبت نشده است.</p>
+        ) : (
+          <ul className="grid gap-4 md:grid-cols-2">
+            {perfumes.map((perfume) => (
+              <li
+                key={perfume.id}
+                className="rounded-[var(--radius-base)] border border-[var(--color-border)] bg-[var(--color-background-soft)]/70 p-4 text-sm shadow-[var(--shadow-soft)]"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-[var(--color-foreground)]">{perfume.name_fa}</p>
+                    <p className="text-xs text-[var(--color-foreground-subtle)]">{perfume.name_en}</p>
+                  </div>
+                  <div className="text-xs text-[var(--color-foreground-muted)]">
+                    {perfume.brand && <p>برند: {perfume.brand.name_fa}</p>}
+                    {perfume.collection && <p>کالکشن: {perfume.collection.name_fa}</p>}
+                  </div>
+                </div>
+                <div className="mt-3 grid gap-2 text-xs text-[var(--color-foreground-muted)]">
+                  <p>
+                    جنسیت: {perfume.gender ?? "---"} | فصل: {perfume.season ?? "---"}
+                  </p>
+                  <p>
+                    خانواده: {perfume.family ?? "---"} | کاراکتر: {perfume.character ?? "---"}
+                  </p>
+                  <div className="space-y-1">
+                    <p className="font-medium text-[var(--color-foreground)]">نت‌ها</p>
+                    <div className="grid gap-1 md:grid-cols-3">
+                      <div>
+                        <p className="text-[var(--color-foreground)]">آغازی</p>
+                        <p>{perfume.notes.top.join("، ") || "---"}</p>
+                      </div>
+                      <div>
+                        <p className="text-[var(--color-foreground)]">میانی</p>
+                        <p>{perfume.notes.middle.join("، ") || "---"}</p>
+                      </div>
+                      <div>
+                        <p className="text-[var(--color-foreground)]">پایانی</p>
+                        <p>{perfume.notes.base.join("، ") || "---"}</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -1,0 +1,288 @@
+import axios from "axios";
+
+import { API_URL, STRAPI_TOKEN } from "./api";
+
+const adminClient = axios.create({
+  baseURL: API_URL,
+});
+
+const authHeaders = (includeContentType = false) => {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+
+  if (includeContentType) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  if (STRAPI_TOKEN) {
+    headers.Authorization = `Bearer ${STRAPI_TOKEN}`;
+  }
+
+  return headers;
+};
+
+interface StrapiEntity<T> {
+  id: number;
+  attributes?: T | null;
+}
+
+interface StrapiListResponse<T> {
+  data: Array<StrapiEntity<T>>;
+}
+
+interface StrapiSingleResponse<T> {
+  data: StrapiEntity<T>;
+}
+
+interface StrapiRelation<T> {
+  data?: StrapiEntity<T> | null;
+}
+
+interface BrandAttributes {
+  name_fa?: string | null;
+  name_en?: string | null;
+  description?: string | null;
+  slug?: string | null;
+  website?: string | null;
+}
+
+export interface AdminBrand {
+  id: number;
+  name_fa: string;
+  name_en: string;
+  description?: string;
+  slug?: string;
+  website?: string;
+}
+
+const mapBrand = (entity: StrapiEntity<BrandAttributes>): AdminBrand => {
+  const attributes = entity.attributes ?? {};
+
+  return {
+    id: entity.id,
+    name_fa: attributes.name_fa?.trim() ?? "",
+    name_en: attributes.name_en?.trim() ?? "",
+    description: attributes.description?.trim() || undefined,
+    slug: attributes.slug?.trim() || undefined,
+    website: attributes.website?.trim() || undefined,
+  };
+};
+
+interface CollectionAttributes {
+  name_fa?: string | null;
+  name_en?: string | null;
+  description?: string | null;
+  slug?: string | null;
+  brand?: StrapiRelation<BrandAttributes>;
+}
+
+export interface AdminCollection {
+  id: number;
+  name_fa: string;
+  name_en: string;
+  description?: string;
+  slug?: string;
+  brand?: AdminBrand | null;
+}
+
+const mapCollection = (
+  entity: StrapiEntity<CollectionAttributes>,
+): AdminCollection => {
+  const attributes = entity.attributes ?? {};
+  const brandData = attributes.brand?.data ?? null;
+
+  return {
+    id: entity.id,
+    name_fa: attributes.name_fa?.trim() ?? "",
+    name_en: attributes.name_en?.trim() ?? "",
+    description: attributes.description?.trim() || undefined,
+    slug: attributes.slug?.trim() || undefined,
+    brand: brandData ? mapBrand(brandData) : null,
+  };
+};
+
+interface PerfumeNotesAttributes {
+  top?: string[] | null;
+  middle?: string[] | null;
+  base?: string[] | null;
+}
+
+export interface PerfumeNotes {
+  top: string[];
+  middle: string[];
+  base: string[];
+}
+
+interface PerfumeAttributes {
+  name_fa?: string | null;
+  name_en?: string | null;
+  description?: string | null;
+  gender?: string | null;
+  season?: string | null;
+  family?: string | null;
+  character?: string | null;
+  notes?: PerfumeNotesAttributes | null;
+  brand?: StrapiRelation<BrandAttributes>;
+  collection?: StrapiRelation<CollectionAttributes>;
+}
+
+export interface AdminPerfume {
+  id: number;
+  name_fa: string;
+  name_en: string;
+  description?: string;
+  gender?: string;
+  season?: string;
+  family?: string;
+  character?: string;
+  notes: PerfumeNotes;
+  brand?: AdminBrand | null;
+  collection?: AdminCollection | null;
+}
+
+const normaliseNotes = (
+  notes: PerfumeNotesAttributes | null | undefined,
+): PerfumeNotes => {
+  const toArray = (value?: string[] | null) =>
+    Array.isArray(value) ? [...value] : [];
+
+  return {
+    top: toArray(notes?.top),
+    middle: toArray(notes?.middle),
+    base: toArray(notes?.base),
+  };
+};
+
+const mapPerfume = (entity: StrapiEntity<PerfumeAttributes>): AdminPerfume => {
+  const attributes = entity.attributes ?? {};
+  const brandData = attributes.brand?.data ?? null;
+  const collectionData = attributes.collection?.data ?? null;
+
+  return {
+    id: entity.id,
+    name_fa: attributes.name_fa?.trim() ?? "",
+    name_en: attributes.name_en?.trim() ?? "",
+    description: attributes.description?.trim() || undefined,
+    gender: attributes.gender?.trim() || undefined,
+    season: attributes.season?.trim() || undefined,
+    family: attributes.family?.trim() || undefined,
+    character: attributes.character?.trim() || undefined,
+    notes: normaliseNotes(attributes.notes),
+    brand: brandData ? mapBrand(brandData) : null,
+    collection: collectionData ? mapCollection(collectionData) : null,
+  };
+};
+
+export interface CreateBrandPayload {
+  name_fa: string;
+  name_en: string;
+  description?: string;
+  slug?: string;
+  website?: string;
+}
+
+export interface CreateCollectionPayload {
+  name_fa: string;
+  name_en: string;
+  description?: string;
+  slug?: string;
+  brand?: number;
+}
+
+export interface CreatePerfumePayload {
+  name_fa: string;
+  name_en: string;
+  description?: string;
+  gender?: string;
+  season?: string;
+  family?: string;
+  character?: string;
+  notes: PerfumeNotes;
+  brand?: number;
+  collection?: number;
+}
+
+export const fetchBrandsAdmin = async (): Promise<AdminBrand[]> => {
+  const response = await adminClient.get<StrapiListResponse<BrandAttributes>>(
+    "/api/brands",
+    {
+      headers: authHeaders(),
+      params: {
+        "pagination[pageSize]": 100,
+        sort: "name_fa:asc",
+      },
+    },
+  );
+
+  return response.data.data.map(mapBrand);
+};
+
+export const fetchCollectionsAdmin = async (): Promise<AdminCollection[]> => {
+  const response = await adminClient.get<
+    StrapiListResponse<CollectionAttributes>
+  >("/api/collections", {
+    headers: authHeaders(),
+    params: {
+      "pagination[pageSize]": 100,
+      populate: "brand",
+      sort: "name_fa:asc",
+    },
+  });
+
+  return response.data.data.map(mapCollection);
+};
+
+export const fetchPerfumesAdmin = async (): Promise<AdminPerfume[]> => {
+  const response = await adminClient.get<StrapiListResponse<PerfumeAttributes>>(
+    "/api/perfumes",
+    {
+      headers: authHeaders(),
+      params: {
+        "pagination[pageSize]": 50,
+        populate: "brand,collection",
+        sort: "updatedAt:desc",
+      },
+    },
+  );
+
+  return response.data.data.map(mapPerfume);
+};
+
+export const createBrand = async (
+  payload: CreateBrandPayload,
+): Promise<AdminBrand> => {
+  const response = await adminClient.post<StrapiSingleResponse<BrandAttributes>>(
+    "/api/brands",
+    { data: payload },
+    { headers: authHeaders(true) },
+  );
+
+  return mapBrand(response.data.data);
+};
+
+export const createCollection = async (
+  payload: CreateCollectionPayload,
+): Promise<AdminCollection> => {
+  const response = await adminClient.post<
+    StrapiSingleResponse<CollectionAttributes>
+  >("/api/collections", { data: payload }, {
+    headers: authHeaders(true),
+    params: { populate: "brand" },
+  });
+
+  return mapCollection(response.data.data);
+};
+
+export const createPerfume = async (
+  payload: CreatePerfumePayload,
+): Promise<AdminPerfume> => {
+  const response = await adminClient.post<
+    StrapiSingleResponse<PerfumeAttributes>
+  >("/api/perfumes", { data: payload }, {
+    headers: authHeaders(true),
+    params: { populate: "brand,collection" },
+  });
+
+  return mapPerfume(response.data.data);
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
-﻿const API_URL = "http://192.168.1.19:1337";
-const STRAPI_TOKEN = process.env.NEXT_PUBLIC_STRAPI_TOKEN;
+﻿export const API_URL = "http://192.168.1.19:1337";
+export const STRAPI_TOKEN = process.env.NEXT_PUBLIC_STRAPI_TOKEN;
 
 type PerfumeAttributeKey = "family" | "season" | "character" | "gender";
 


### PR DESCRIPTION
## Summary
- export the Strapi API configuration and add an authenticated admin client with helper functions for brands, collections, and perfumes
- create an RTL admin layout with navigation and a dashboard entry page for managing catalogue data
- build Persian react-hook-form pages for brands, collections, and products that submit to Strapi, display feedback, and refresh lists after success

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7f4e7ac808320a9a1f44f2697a93e