### PR TITLE
Fix admin brand fetching for updated Strapi fields

### DIFF
--- a/src/app/admin/brands/page.tsx
+++ b/src/app/admin/brands/page.tsx
@@ -32,6 +32,10 @@ const defaultValues: BrandFormValues = {
 };
 
 const buildPayload = (values: BrandFormValues): CreateBrandPayload => ({
+  name:
+    values.nameFa.trim() ||
+    values.nameEn.trim() ||
+    "",
   name_fa: values.nameFa.trim(),
   name_en: values.nameEn.trim(),
   description: values.description?.trim() || undefined,

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -40,6 +40,7 @@ interface StrapiRelation<T> {
 }
 
 interface BrandAttributes {
+  name?: string | null;
   name_fa?: string | null;
   name_en?: string | null;
   description?: string | null;
@@ -49,6 +50,7 @@ interface BrandAttributes {
 
 export interface AdminBrand {
   id: number;
+  name: string;
   name_fa: string;
   name_en: string;
   description?: string;
@@ -58,11 +60,17 @@ export interface AdminBrand {
 
 const mapBrand = (entity: StrapiEntity<BrandAttributes>): AdminBrand => {
   const attributes = entity.attributes ?? {};
+  const name = attributes.name?.trim() ?? null;
+  const nameFa = attributes.name_fa?.trim() ?? null;
+  const nameEn = attributes.name_en?.trim() ?? null;
+  const fallbackName = nameFa ?? nameEn ?? "";
+  const resolvedName = name ?? fallbackName;
 
   return {
     id: entity.id,
-    name_fa: attributes.name_fa?.trim() ?? "",
-    name_en: attributes.name_en?.trim() ?? "",
+    name: resolvedName,
+    name_fa: nameFa ?? resolvedName,
+    name_en: nameEn ?? resolvedName,
     description: attributes.description?.trim() || undefined,
     slug: attributes.slug?.trim() || undefined,
     website: attributes.website?.trim() || undefined,
@@ -175,6 +183,7 @@ const mapPerfume = (entity: StrapiEntity<PerfumeAttributes>): AdminPerfume => {
 };
 
 export interface CreateBrandPayload {
+  name: string;
   name_fa: string;
   name_en: string;
   description?: string;
@@ -210,7 +219,7 @@ export const fetchBrandsAdmin = async (): Promise<AdminBrand[]> => {
       headers: authHeaders(),
       params: {
         "pagination[pageSize]": 100,
-        sort: "name_fa:asc",
+        sort: "name:asc",
       },
     },
   );


### PR DESCRIPTION
## Summary
- update admin brand mapper and payloads to use the Strapi `name` attribute with fallbacks for localized fields
- request brands sorted by `name` to match the available backend columns

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7f9bef07483209584a0338e0d8538