### PR TITLE
Fix collections admin sort field

### DIFF
--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -235,7 +235,7 @@ export const fetchCollectionsAdmin = async (): Promise<AdminCollection[]> => {
     params: {
       "pagination[pageSize]": 100,
       populate: "brand",
-      sort: "name_fa:asc",
+      sort: "name:asc",
     },
   });
 


### PR DESCRIPTION
## Summary
- update the admin collections fetch to sort using the valid `name` field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7fb4b9c2c83208fc3b966cdb2998c